### PR TITLE
Update quick-start.sh, workflows, and README

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -13,8 +13,9 @@ on:
 
 jobs:
   deployment:
-    name: Deploy to GCP
+    name: Deploy to Azure
     runs-on: ubuntu-latest
+    environment: main
     defaults:
       run:
         shell: bash
@@ -53,7 +54,7 @@ jobs:
 
       - name: Set environment
         run: |-
-          echo "ENVIRONMENT=$(
+          echo "TF_ENVIRONMENT=$(
           if "${{ github.event.inputs.environment }}"; then
             echo ${{ github.event.inputs.environment }}
           else
@@ -65,7 +66,7 @@ jobs:
         run: terraform init -backend-config=backend.tfvars
 
       - name: terraform workspace
-        run: terraform workspace select ${{ env.ENVIRONMENT }} || terraform workspace new ${{ env.ENVIRONMENT }}
+        run: terraform workspace select ${{ env.TF_ENVIRONMENT }} || terraform workspace new ${{ env.TF_ENVIRONMENT }}
 
       - name: terraform apply
         run: terraform apply -auto-approve -lock-timeout=30m

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -26,30 +26,30 @@ jobs:
       - name: Check Out Changes
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - id: "auth"
-        name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v0"
+      - name: "Azure login"
+        uses: azure/login@v1
         with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.SERVICE_ACCOUNT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
 
       - name: Load input variables
         env:
-          PROJECT_ID: ${{ secrets.PROJECT_ID }}
-          REGION: ${{ secrets.REGION }}
-          ZONE: ${{ secrets.ZONE }}
+          SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          LOCATION: ${{ secrets.LOCATION }}
+          RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
           SMARTY_AUTH_ID: ${{ secrets.SMARTY_AUTH_ID }}
           SMARTY_AUTH_TOKEN: ${{ secrets.SMARTY_AUTH_TOKEN }}
         run: |
-          echo project_id=\""$PROJECT_ID"\" >> terraform.tfvars
-          echo region=\""$REGION"\" >> terraform.tfvars
-          echo zone=\""$ZONE"\" >> terraform.tfvars
+          echo subscription_id=\""$SUBSCRIPTION_ID"\" >> terraform.tfvars
+          echo location=\""$LOCATION"\" >> terraform.tfvars
+          echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> terraform.tfvars
           echo smarty_auth_id=\""$SMARTY_AUTH_ID"\" >> terraform.tfvars
           echo smarty_auth_token=\""$SMARTY_AUTH_TOKEN"\" >> terraform.tfvars
-          echo bucket=\"phdi-tfstate-"$PROJECT_ID"\" >> backend.tfvars
+          echo subscription_id=\""$SUBSCRIPTION_ID"\" >> backend.tfvars
+          echo tenant_id=\""$TENANT_ID"\" >> backend.tfvars
+          echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> backend.tfvars
+          echo storage_account_name=\"phdi-tfstate-"$SUBSCRIPTION_ID"\" >> backend.tfvars
 
       - name: Set environment
         run: |-
@@ -66,21 +66,6 @@ jobs:
 
       - name: terraform workspace
         run: terraform workspace select ${{ env.ENVIRONMENT }} || terraform workspace new ${{ env.ENVIRONMENT }}
-
-      - name: Create artifact registry
-        run: terraform apply -target="module.artifact-registries" -auto-approve -lock-timeout=30m
-
-      - name: Log in to artifact registry with docker
-        run: gcloud auth configure-docker ${{ secrets.REGION }}-docker.pkg.dev
-
-      - name: Build and push FHIR Converter
-        uses: docker/build-push-action@v3
-        with:
-          context: ./cloud-run/fhir-converter
-          push: true
-          tags: ${{ secrets.REGION }}-docker.pkg.dev/${{ secrets.PROJECT_ID }}/phdi-${{ env.ENVIRONMENT }}-repository/fhir-converter:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: terraform apply
         run: terraform apply -auto-approve -lock-timeout=30m

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -47,8 +47,6 @@ jobs:
           echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> terraform.tfvars
           echo smarty_auth_id=\""$SMARTY_AUTH_ID"\" >> terraform.tfvars
           echo smarty_auth_token=\""$SMARTY_AUTH_TOKEN"\" >> terraform.tfvars
-          echo subscription_id=\""$SUBSCRIPTION_ID"\" >> backend.tfvars
-          echo tenant_id=\""$TENANT_ID"\" >> backend.tfvars
           echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> backend.tfvars
           echo storage_account_name=\"phdi-tfstate-"$SUBSCRIPTION_ID"\" >> backend.tfvars
 
@@ -62,11 +60,12 @@ jobs:
           fi
           )" >> $GITHUB_ENV
 
-      - name: terraform init
-        run: terraform init -backend-config=backend.tfvars
-
-      - name: terraform workspace
-        run: terraform workspace select ${{ env.TF_ENVIRONMENT }} || terraform workspace new ${{ env.TF_ENVIRONMENT }}
-
-      - name: terraform apply
-        run: terraform apply -auto-approve -lock-timeout=30m
+      - name: terraform
+        env:
+          ARM_CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+        run: |
+          terraform init -backend-config=backend.tfvars
+          terraform workspace select ${{ env.TF_ENVIRONMENT }} || terraform workspace new ${{ env.TF_ENVIRONMENT }}
+          terraform apply -auto-approve -lock-timeout=30m

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -11,6 +11,9 @@ on:
   #   branches:
   #     - main
 
+permissions:
+  id-token: write
+  contents: read
 jobs:
   deployment:
     name: Deploy to Azure
@@ -20,9 +23,6 @@ jobs:
       run:
         shell: bash
         working-directory: ./terraform/implementation
-    permissions:
-      contents: "read"
-      id-token: "write"
     steps:
       - name: Check Out Changes
         uses: actions/checkout@v3

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -48,7 +48,7 @@ jobs:
           echo smarty_auth_id=\""$SMARTY_AUTH_ID"\" >> terraform.tfvars
           echo smarty_auth_token=\""$SMARTY_AUTH_TOKEN"\" >> terraform.tfvars
           echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> backend.tfvars
-          echo storage_account_name=\"phdi-tfstate-"$SUBSCRIPTION_ID"\" >> backend.tfvars
+          echo storage_account_name=\"phditfstate"${SUBSCRIPTION_ID:0:8}"\" >> backend.tfvars
 
       - name: Set environment
         run: |-

--- a/.github/workflows/terraformSetup.yaml
+++ b/.github/workflows/terraformSetup.yaml
@@ -5,8 +5,9 @@ on:
 
 jobs:
   setup_environment:
-    name: Setup a new GCP environment by creating a tfstate bucket
+    name: Setup a new Azure environment by creating a tfstate bucket
     runs-on: ubuntu-latest
+    environment: main
     defaults:
       run:
         shell: bash

--- a/.github/workflows/terraformSetup.yaml
+++ b/.github/workflows/terraformSetup.yaml
@@ -18,22 +18,22 @@ jobs:
       - name: Check Out Changes
         uses: actions/checkout@v3
 
-      - id: "auth"
-        name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v0"
+      - name: "Azure login"
+        uses: azure/login@v1
         with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.SERVICE_ACCOUNT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
 
       - name: Load input variables
         env:
-          PROJECT_ID: ${{ secrets.PROJECT_ID }}
-          REGION: ${{ secrets.REGION }}
-          ZONE: ${{ secrets.ZONE }}
+          SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          LOCATION: ${{ secrets.LOCATION }}
+          RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
         run: |
-          echo project_id=\""$PROJECT_ID"\" >> terraform.tfvars
-          echo region=\""$REGION"\" >> terraform.tfvars
-          echo zone=\""$ZONE"\" >> terraform.tfvars
+          echo subscription_id=\""$SUBSCRIPTION_ID"\" >> terraform.tfvars
+          echo location=\""$LOCATION"\" >> terraform.tfvars
+          echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> terraform.tfvars
 
       - name: terraform init
         run: terraform init

--- a/.github/workflows/terraformSetup.yaml
+++ b/.github/workflows/terraformSetup.yaml
@@ -3,6 +3,9 @@ name: Terraform Setup
 on:
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
 jobs:
   setup_environment:
     name: Setup a new Azure environment by creating a tfstate bucket
@@ -12,9 +15,6 @@ jobs:
       run:
         shell: bash
         working-directory: ./terraform/setup
-    permissions:
-      contents: "read"
-      id-token: "write"
     steps:
       - name: Check Out Changes
         uses: actions/checkout@v3

--- a/.github/workflows/terraformSetup.yaml
+++ b/.github/workflows/terraformSetup.yaml
@@ -36,8 +36,11 @@ jobs:
           echo location=\""$LOCATION"\" >> terraform.tfvars
           echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> terraform.tfvars
 
-      - name: terraform init
-        run: terraform init
-
-      - name: terraform apply
-        run: terraform apply -auto-approve -lock-timeout=30m
+      - name: terraform
+        env:
+          ARM_CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+        run: |
+          terraform init
+          terraform apply -auto-approve -lock-timeout=30m

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ data/
 
 .DS_Store
 
-# GCP Application Creds
+# Azure Application Creds
 appcreds.json
 # Terraform
 .terraform

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ terraform.tfstate.d
 terraform.tfstate.backup
 *.tfvars
 .vscode/settings.json
+credentials.json

--- a/credentials.json
+++ b/credentials.json
@@ -1,0 +1,7 @@
+{
+  "name": "github",
+  "issuer": "https://token.actions.githubusercontent.com/",
+  "subject": "repo:skylight-hq/phdi-azure:ref:refs/heads/main",
+  "description": "GitHub Actions",
+  "audiences": ["api://AzureADTokenExchange"]
+}

--- a/credentials.json
+++ b/credentials.json
@@ -1,7 +1,0 @@
-{
-  "name": "github",
-  "issuer": "https://token.actions.githubusercontent.com/",
-  "subject": "repo:skylight-hq/phdi-azure:ref:refs/heads/main",
-  "description": "GitHub Actions",
-  "audiences": ["api://AzureADTokenExchange"]
-}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Public Health Data Infrastructure Azure
 
-- [Public Health Data Infrastructure Azure](#public-health-data-infrastructure-google-cloud)
+- [Public Health Data Infrastructure Azure](#public-health-data-infrastructure-azure)
   - [Overview](#overview)
     - [Quick Start](#quick-start)
     - [Structure and Organizations](#structure-and-organization)
@@ -30,28 +30,28 @@ The Public Health Data Infrastructure (PHDI) projects are part of the Pandemic-R
 To deploy this pipeline to your own Azure environment, follow these steps.
   
   Be sure to replace all instances of `myuser` in GitHub URLs with your user or organization name.
-  1. [Install the gcloud CLI](https://cloud.google.com/sdk/docs/install-sdk)
+  1. [Install the az CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
   1. [Install the GitHub CLI](https://cli.github.com/manual/installation) (optional)
-  1. [Fork this repository](https://github.com/myuser/phdi-google-cloud/fork) into your personal or organization account
+  1. [Fork this repository](https://github.com/myuser/phdi-azure/fork) into your personal or organization account
   1. Clone your newly forked repository to your local machine by running:
 
-         git clone https://github.com/myuser/phdi-google-cloud.git
+         git clone https://github.com/myuser/phdi-azure.git
 
   1. Navigate to the new repository directory with:
 
-         cd phdi-google-cloud
+         cd phdi-azure
 
   1. Authenticate the gcloud CLI by running:
 
          ./quick-start.sh
 
-  1. Follow [these steps](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) to set the secrets output by the previous step in your repository.
-  1. Setup a storage bucket for Terraform state by running the GitHub Action at this URL:  
-  https://github.com/myuser/phdi-google-cloud/actions/workflows/terraformSetup.yaml
+  1. If you did not install the GitHub CLI, follow [these steps](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) to set the secrets output by the previous step in your repository.
+  1. Setup a storage account for Terraform state by running the GitHub Action at this URL:  
+  https://github.com/myuser/phdi-azure/actions/workflows/terraformSetup.yaml
   1. Create an environment named `dev` in your repository at this URL:  
-  https://github.com/myuser/phdi-google-cloud/settings/environments/new
+  https://github.com/myuser/phdi-azure/settings/environments/new
   1. Deploy to your newly created `dev` environment by running the GitHub Action at this URL, selecting `dev` as the environment input:  
-  https://github.com/myuser/phdi-google-cloud/actions/workflows/deployment.yaml
+  https://github.com/myuser/phdi-azure/actions/workflows/deployment.yaml
   1. Success! You should now see resources in your Azure project ready for data ingestion.
 
 ### Structure and Organization
@@ -60,7 +60,7 @@ There are primarily four major components to this repository.
 
 #### Serverless Functions
 
-The PHDI Building Blocks are implemented as Azure Functions. Azure Functions are Azure's version of serverless functions, similar to Lamabda in Amazon Web Services (AWS) and Azure Functions in Mircosoft Azure. Severless function provide a relatively simple way to run services with modest runtime duration, memory, and compute requirements in the cloud. Since they are serverless, Azure abstracts all aspects of the underlying infrastructure allowing us to simply write and excute our Building Blocks without worrying about the computers they run on. The `cloud-functions` directory contains Python source code for Azure Functions that implement Building Blocks from the PHDI SDK.
+The PHDI Building Blocks are implemented as Azure Function Apps. Azure Function Apps are Azure's version of serverless functions, similar to Lambda in Amazon Web Services (AWS) and Azure Function Apps in Mircosoft Azure. Severless function provide a relatively simple way to run services with modest runtime duration, memory, and compute requirements in the cloud. Since they are serverless, Azure abstracts all aspects of the underlying infrastructure allowing us to simply write and excute our Building Blocks without worrying about the computers they run on. The `cloud-functions` directory contains Python source code for Azure Function Apps that implement Building Blocks from the PHDI SDK.
 
 #### Pipeline Orchestration
 

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -2,8 +2,8 @@
 
 ################################################################################
 #
-# This script is used to setup gcloud authentication for GitHub Actions.
-# It is based on the following guide: https://github.com/google-github-actions/auth#setup
+# This script is used to setup Azure authentication for GitHub Actions.
+# It is based on the following guide: https://learn.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azcli
 #
 ################################################################################
 
@@ -12,16 +12,16 @@ print_variables() {
   echo "Please load the following variables into your repository secrets at this URL:"
   echo "https://github.com/$GITHUB_REPO/settings/secrets/actions"
   echo
-  echo "PROJECT_ID: ${PROJECT_ID}"
-  echo "SERVICE_ACCOUNT_ID: ${SERVICE_ACCOUNT_ID}"
-  echo "WORKLOAD_IDENTITY_PROVIDER: ${WORKLOAD_IDENTITY_PROVIDER}"
-  echo "REGION: us-central1 (or your preferred region)"
-  echo "ZONE: us-central1-a (or your preferred zone in the region above)"
+  echo "TENANT_ID: ${TENANT_ID}"
+  echo "SUBSCRIPTION_ID: ${SUBSCRIPTION_ID}"
+  echo "CLIENT_ID: ${CLIENT_ID}"
+  echo "RESOURCE_GROUP_ID: ${RESOURCE_GROUP_ID}"
+  echo "LOCATION: ${LOCATION}"
   echo "SMARTY_AUTH_ID: Your Smarty Streets App Authorization ID"
   echo "SMARTY_AUTH_TOKEN: Your Smarty Streets App Authorization Token"
   echo
-  echo "More info on regions and zones can be found at:"
-  echo "https://cloud.google.com/compute/docs/regions-zones/"
+  echo "More info on locations can be found at:"
+  echo "https://azure.microsoft.com/en-us/explore/global-infrastructure/geographies/#overview"
   echo
   echo "You can now continue with the Quick Start instructions in the README.md file."
 }
@@ -36,14 +36,6 @@ set_variables() {
     exit
   fi
 
-  echo "Please enter the name of the region you would like to deploy to (e.g. us-central1)."
-  echo "More info: https://cloud.google.com/compute/docs/regions-zones/regions-zones"
-  read REGION
-
-  echo "Please enter the name of the zone you would like to deploy to (e.g. us-central1-a)."
-  echo "More info: https://cloud.google.com/compute/docs/regions-zones/regions-zones"
-  read ZONE
-
   echo "Please enter the authorization id of your Smarty Street Account."
   echo "More info:   https://www.smarty.com/docs/cloud/authentication"
   read SMARTY_AUTH_ID
@@ -56,11 +48,11 @@ set_variables() {
   gh auth login
 
   echo "Setting repository secrets..."
-  gh secret -R "${GITHUB_REPO}" set PROJECT_ID --body "${PROJECT_ID}" 
-  gh secret -R "${GITHUB_REPO}" set SERVICE_ACCOUNT_ID --body "${SERVICE_ACCOUNT_ID}"
-  gh secret -R "${GITHUB_REPO}" set WORKLOAD_IDENTITY_PROVIDER --body "${WORKLOAD_IDENTITY_PROVIDER}"
-  gh secret -R "${GITHUB_REPO}" set REGION --body "${REGION}"
-  gh secret -R "${GITHUB_REPO}" set ZONE --body "${ZONE}"
+  gh secret -R "${GITHUB_REPO}" set TENANT_ID --body "${TENANT_ID}"
+  gh secret -R "${GITHUB_REPO}" set SUBSCRIPTION_ID --body "${SUBSCRIPTION_ID}"
+  gh secret -R "${GITHUB_REPO}" set CLIENT_ID --body "${CLIENT_ID}"
+  gh secret -R "${GITHUB_REPO}" set RESOURCE_GROUP_ID --body "${RESOURCE_GROUP_ID}"
+  gh secret -R "${GITHUB_REPO}" set LOCATION --body "${LOCATION}"
   gh secret -R "${GITHUB_REPO}" set SMARTY_AUTH_ID --body "${SMARTY_AUTH_ID}"
   gh secret -R "${GITHUB_REPO}" set SMARTY_AUTH_TOKEN --body "${SMARTY_AUTH_TOKEN}"
 
@@ -68,99 +60,61 @@ set_variables() {
   echo "You can now continue with the Quick Start instructions in the README.md file."
 }
 
-# Prompt user for project name and repository name
-echo "Welcome to the PHDI Google Cloud setup script!"
-echo "This script will help you setup gcloud authentication for GitHub Actions."
+# Prompt user for resource group name and repository name
+echo "Welcome to the PHDI Azure setup script!"
+echo "This script will help you setup az CLI authentication for GitHub Actions."
 echo "We need some info from you to get started."
-echo "After entering the info, a browser window will open for you to authenticate with Google Cloud."
+echo "After entering the info, a browser window will open for you to authenticate with Azure."
 echo
 while true; do
-    read -p "Do you already have a Project in Google Cloud Platform? (y/n) " yn
+    read -p "Do you already have a Resource Group in Azure? (y/n) " yn
     case $yn in
-        [Yy]* ) read -p "Please enter the name of the existing Project. " PROJECT_NAME; NEW_PROJECT=false; break;;
-        [Nn]* ) read -p "Please enter a name for a new Project. " PROJECT_NAME; NEW_PROJECT=true; break;;
+        [Yy]* ) read -p "Please enter the name of the existing Resource Group. " RESOURCE_GROUP_NAME; NEW_RESOURCE_GROUP=false; break;;
+        [Nn]* ) read -p "Please enter a name for a new Resource Group. " RESOURCE_GROUP_NAME; NEW_RESOURCE_GROUP=true; break;;
         * ) echo "Please answer y or n.";;
     esac
 done
 echo "Please enter the name of the repository you will be deploying from."
-echo "For example, if your repo URL is https://github.com/CDCgov/phdi-google-cloud, enter: CDCgov/phdi-google-cloud"
+echo "For example, if your repo URL is https://github.com/CDCgov/phdi-azure, enter: CDCgov/phdi-azure"
 read GITHUB_REPO
 
-# Login to Google Cloud Platform
-gcloud auth login
+echo "Please enter the name of the location you would like to deploy to (e.g. centralus)."
+echo "More info: https://azure.microsoft.com/en-us/explore/global-infrastructure/geographies/#overview"
+read LOCATION
 
-# Create a project if needed and get the project ID
-if [ $NEW_PROJECT = true ]; then
-    gcloud projects create --name="${PROJECT_NAME}"
+# Login to Azure, get tenant and subscription IDs
+az login
+TENANT_ID=$(az account show --query "tenantId" -o tsv)
+SUBSCRIPTION_ID="$(az account show --query "id" -o tsv)"
+
+# Create a resource group if needed and get the resource group ID
+if [ $NEW_RESOURCE_GROUP = true ]; then
+    az group create --name "${RESOURCE_GROUP_NAME}" --location "${LOCATION}"
 fi
-PROJECT_ID=$(gcloud projects list --filter="name:'${PROJECT_NAME}'" --format="value(projectId)")
-if [ -z "$PROJECT_ID" ]; then
-    echo "Error: Project ID not found. To list projects, run 'gcloud projects list'."
+RESOURCE_GROUP_ID=$(az group show --name "${RESOURCE_GROUP_NAME}" --query "id" -o tsv)
+if [ -z "$RESOURCE_GROUP_ID" ]; then
+    echo "Error: Resource Group ID not found. To list resource groups, run 'az group list'."
     exit 1
 fi
 
-# Set the current project to the PROJECT_ID specified above
-gcloud config set project "${PROJECT_ID}"
+# Set the current resource group to the RESOURCE_GROUP_ID specified above
+az config set defaults.group="${RESOURCE_GROUP_NAME}"
 
-# Enable necessary APIs
-gcloud services enable \
-    iam.googleapis.com \
-    cloudresourcemanager.googleapis.com \
-    iamcredentials.googleapis.com \
-    sts.googleapis.com \
-    serviceusage.googleapis.com
+# Define app registration name, get client ID.
+APP_REG_NAME=github
+CLIENT_ID=$(az ad app create --display-name $APP_REG_NAME --query appId --output tsv)
 
-# Create a service account
-gcloud iam service-accounts create "github" \
-  --project "${PROJECT_ID}" \
-  --display-name "github"
-
-# Get the service account ID and set some variables
-SERVICE_ACCOUNT_ID=$(gcloud iam service-accounts list --filter="displayName:github" --format="value(email)")
-
-# Grant the service account the owner role on the project
-gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-  --member="serviceAccount:${SERVICE_ACCOUNT_ID}" \
-  --role="roles/owner"
-
-if [ $NEW_PROJECT = true ]; then
-    echo "Waiting 60 seconds for Workload Identity Federation to be created."
-    sleep 60
-fi
-
-# Create a Workload Identity Pool
-gcloud iam workload-identity-pools create "github-pool" \
-  --project="${PROJECT_ID}" \
-  --location="global" \
-  --display-name="github pool"
-
-# Get the full ID of the Workload Identity Pool
-WORKLOAD_IDENTITY_POOL_ID=$(gcloud iam workload-identity-pools describe "github-pool" \
-  --project="${PROJECT_ID}" \
-  --location="global" \
-  --format="value(name)")
-
-# Create a Workload Identity Provider in that pool
-gcloud iam workload-identity-pools providers create-oidc "github-provider" \
-  --project="${PROJECT_ID}" \
-  --location="global" \
-  --workload-identity-pool="github-pool" \
-  --display-name="github provider" \
-  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository" \
-  --issuer-uri="https://token.actions.githubusercontent.com"
-
-# Allow authentications from the Workload Identity Provider originating from your repository to impersonate the Service Account created above
-gcloud iam service-accounts add-iam-policy-binding "${SERVICE_ACCOUNT_ID}" \
-  --project="${PROJECT_ID}" \
-  --role="roles/iam.workloadIdentityUser" \
-  --member="principalSet://iam.googleapis.com/${WORKLOAD_IDENTITY_POOL_ID}/attribute.repository/${GITHUB_REPO}"
-
-# Extract the Workload Identity Provider resource name
-WORKLOAD_IDENTITY_PROVIDER=$(gcloud iam workload-identity-pools providers describe "github-provider" \
-  --project="${PROJECT_ID}" \
-  --location="global" \
-  --workload-identity-pool="github-pool" \
-  --format="value(name)")
+# Create federated credential
+cat << EOF > credentials.json
+{
+  "name": "$APP_REG_NAME",
+  "issuer": "https://token.actions.githubusercontent.com/",
+  "subject": "repo:$GITHUB_REPO:ref:refs/heads/main",
+  "description": "GitHub Actions",
+  "audiences": ["api://AzureADTokenExchange"]
+}
+EOF
+az ad app federated-credential create --id $CLIENT_ID --parameters credentials.json
 
 echo "Workload Identity Federation setup complete!"
 echo

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -109,7 +109,7 @@ cat << EOF > credentials.json
 {
   "name": "$APP_REG_NAME",
   "issuer": "https://token.actions.githubusercontent.com/",
-  "subject": "repo:$GITHUB_REPO:ref:refs/heads/main",
+  "subject": "repo:$GITHUB_REPO:environment:main",
   "description": "GitHub Actions",
   "audiences": ["api://AzureADTokenExchange"]
 }

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -104,11 +104,14 @@ az config set defaults.group="${RESOURCE_GROUP_NAME}"
 APP_REG_NAME=github
 CLIENT_ID=$(az ad app create --display-name $APP_REG_NAME --query appId --output tsv)
 
+# Create service principal and grant access to subscription
+az ad sp create-for-rbac --scopes $SUBSCRIPTION_ID --role contributor --name $APP_REG_NAME
+
 # Create federated credential
 cat << EOF > credentials.json
 {
   "name": "$APP_REG_NAME",
-  "issuer": "https://token.actions.githubusercontent.com/",
+  "issuer": "https://token.actions.githubusercontent.com",
   "subject": "repo:$GITHUB_REPO:environment:main",
   "description": "GitHub Actions",
   "audiences": ["api://AzureADTokenExchange"]

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -15,7 +15,7 @@ print_variables() {
   echo "TENANT_ID: ${TENANT_ID}"
   echo "SUBSCRIPTION_ID: ${SUBSCRIPTION_ID}"
   echo "CLIENT_ID: ${CLIENT_ID}"
-  echo "RESOURCE_GROUP_ID: ${RESOURCE_GROUP_ID}"
+  echo "RESOURCE_GROUP_NAME: ${RESOURCE_GROUP_NAME}"
   echo "LOCATION: ${LOCATION}"
   echo "SMARTY_AUTH_ID: Your Smarty Streets App Authorization ID"
   echo "SMARTY_AUTH_TOKEN: Your Smarty Streets App Authorization Token"
@@ -51,7 +51,7 @@ set_variables() {
   gh secret -R "${GITHUB_REPO}" set TENANT_ID --body "${TENANT_ID}"
   gh secret -R "${GITHUB_REPO}" set SUBSCRIPTION_ID --body "${SUBSCRIPTION_ID}"
   gh secret -R "${GITHUB_REPO}" set CLIENT_ID --body "${CLIENT_ID}"
-  gh secret -R "${GITHUB_REPO}" set RESOURCE_GROUP_ID --body "${RESOURCE_GROUP_ID}"
+  gh secret -R "${GITHUB_REPO}" set RESOURCE_GROUP_NAME --body "${RESOURCE_GROUP_NAME}"
   gh secret -R "${GITHUB_REPO}" set LOCATION --body "${LOCATION}"
   gh secret -R "${GITHUB_REPO}" set SMARTY_AUTH_ID --body "${SMARTY_AUTH_ID}"
   gh secret -R "${GITHUB_REPO}" set SMARTY_AUTH_TOKEN --body "${SMARTY_AUTH_TOKEN}"
@@ -97,7 +97,7 @@ if [ -z "$RESOURCE_GROUP_ID" ]; then
     exit 1
 fi
 
-# Set the current resource group to the RESOURCE_GROUP_ID specified above
+# Set the current resource group to the RESOURCE_GROUP_NAME specified above
 az config set defaults.group="${RESOURCE_GROUP_NAME}"
 
 # Define app registration name, get client ID.

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -105,7 +105,7 @@ APP_REG_NAME=github
 CLIENT_ID=$(az ad app create --display-name $APP_REG_NAME --query appId --output tsv)
 
 # Create service principal and grant access to subscription
-az ad sp create-for-rbac --scopes $SUBSCRIPTION_ID --role contributor --name $APP_REG_NAME
+az ad sp create-for-rbac --scopes /subscriptions/$SUBSCRIPTION_ID --role contributor --name $APP_REG_NAME
 
 # Create federated credential
 cat << EOF > credentials.json

--- a/terraform/implementation/backend.tf
+++ b/terraform/implementation/backend.tf
@@ -7,6 +7,7 @@ terraform {
   }
 
   backend "azurerm" {
+    use_oidc       = true
     container_name = "tfstate"
     key            = "prod.terraform.tfstate"
     use_msi        = true
@@ -14,6 +15,6 @@ terraform {
 }
 
 provider "azurerm" {
+  use_oidc = true
   features {}
-  subscription_id = var.subscription_id
 }

--- a/terraform/implementation/backend.tf
+++ b/terraform/implementation/backend.tf
@@ -7,17 +7,13 @@ terraform {
   }
 
   backend "azurerm" {
-    resource_group_name  = "StorageAccount-ResourceGroup"
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
-    use_msi              = true
-    subscription_id      = "00000000-0000-0000-0000-000000000000"
-    tenant_id            = "00000000-0000-0000-0000-000000000000"
+    container_name = "tfstate"
+    key            = "prod.terraform.tfstate"
+    use_msi        = true
   }
 }
 
 provider "azurerm" {
   features {}
-  subscription_id            = var.subscription_id
+  subscription_id = var.subscription_id
 }

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "testbucket" {
-  name                     = "phdi-testbucket-${substr(var.subscription_id, 0, 8)}"
+  name                     = "testbucketPHDI${substr(var.subscription_id, 0, 8)}"
   resource_group_name      = var.resource_group_name
   location                 = var.location
   account_tier             = "Standard"

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -1,0 +1,12 @@
+resource "azurerm_storage_account" "testbucket" {
+  name                     = "phdi-testbucket-${var.subscription_id}"
+  resource_group_name      = var.resource_group_name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_kind             = "StorageV2"
+  account_replication_type = "GRS"
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "testbucket" {
-  name                     = "testbucketPHDI${substr(var.subscription_id, 0, 8)}"
+  name                     = "phditestbucket${substr(var.subscription_id, 0, 8)}"
   resource_group_name      = var.resource_group_name
   location                 = var.location
   account_tier             = "Standard"

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "testbucket" {
-  name                     = "phdi-testbucket-${var.subscription_id}"
+  name                     = "phdi-testbucket-${substr(var.subscription_id, 0, 8)}"
   resource_group_name      = var.resource_group_name
   location                 = var.location
   account_tier             = "Standard"

--- a/terraform/implementation/variables.tf
+++ b/terraform/implementation/variables.tf
@@ -1,5 +1,3 @@
-
-
 variable "subscription_id" {
   description = "value of the Azure Subscription ID to use"
 }
@@ -9,7 +7,6 @@ variable "location" {
   default     = "Central US"
 }
 
-variable "zone" {
-  description = "value of the Azure zone to deploy to"
-  default     = "Zone 1"
+variable "resource_group_name" {
+  description = "value of the Azure resource group to deploy to"
 }

--- a/terraform/modules/artifact-registries/variables.tf
+++ b/terraform/modules/artifact-registries/variables.tf
@@ -1,4 +1,4 @@
 variable "region" {
   type        = string
-  description = "The GCP region to deploy to"
+  description = "The Azure region to deploy to"
 }

--- a/terraform/modules/cloud-functions/variables.tf
+++ b/terraform/modules/cloud-functions/variables.tf
@@ -1,5 +1,5 @@
 variable "project_id" {
-  description = "value of the GCP project ID to use"
+  description = "value of the Azure project ID to use"
 }
 
 variable "functions_storage_bucket" {

--- a/terraform/modules/cloud-run/variables.tf
+++ b/terraform/modules/cloud-run/variables.tf
@@ -1,11 +1,11 @@
 variable "region" {
   type        = string
-  description = "The GCP region to deploy to"
+  description = "The Azure region to deploy to"
 }
 
 variable "project_id" {
   type        = string
-  description = "value of the GCP project ID to use"
+  description = "value of the Azure project ID to use"
 }
 
 variable "workflow_service_account_email" {

--- a/terraform/modules/fhir/variables.tf
+++ b/terraform/modules/fhir/variables.tf
@@ -12,10 +12,10 @@ variable "fhir_version" {
 
 variable "region" {
   type        = string
-  description = "The GCP region to deploy to"
+  description = "The Azure region to deploy to"
   default     = "us-east1"
 }
 
 variable "project_id" {
-  description = "value of the GCP project ID to use"
+  description = "value of the Azure project ID to use"
 }

--- a/terraform/modules/google-workflows/variables.tf
+++ b/terraform/modules/google-workflows/variables.tf
@@ -1,10 +1,10 @@
 variable "project_id" {
   type        = string
-  description = "value of the GCP project ID to use"
+  description = "value of the Azure project ID to use"
 }
 
 variable "region" {
-  description = "GCP region to deploy to"
+  description = "Azure region to deploy to"
   default     = "us-east1"
 }
 

--- a/terraform/modules/network/variables.tf
+++ b/terraform/modules/network/variables.tf
@@ -1,4 +1,4 @@
 variable "region" {
-  description = "value of the GCP region to deploy to"
+  description = "value of the Azure region to deploy to"
   default     = "us-east1"
 }

--- a/terraform/modules/pubsub/variables.tf
+++ b/terraform/modules/pubsub/variables.tf
@@ -1,6 +1,6 @@
 variable "project_id" {
   type        = string
-  description = "value of the GCP project ID to use"
+  description = "value of the Azure project ID to use"
 }
 
 variable "workflow_service_account_email" {

--- a/terraform/modules/secret-manager/variables.tf
+++ b/terraform/modules/secret-manager/variables.tf
@@ -1,6 +1,6 @@
 variable "project_id" {
   type        = string
-  description = "value of the GCP project ID to use"
+  description = "value of the Azure project ID to use"
 }
 
 variable "workflow_service_account_email" {

--- a/terraform/modules/storage/variables.tf
+++ b/terraform/modules/storage/variables.tf
@@ -1,3 +1,3 @@
 variable "project_id" {
-  description = "value of the GCP project ID to use"
+  description = "value of the Azure project ID to use"
 }

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -34,3 +34,8 @@ resource "azurerm_storage_account" "tfstate" {
     prevent_destroy = true
   }
 }
+
+resource "azurerm_storage_container" "tfstate" {
+  name                 = "tfstate"
+  storage_account_name = azurerm_storage_account.tfstate.name
+}

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -23,7 +23,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_storage_account" "tfstate" {
-  name                     = "phdi-tfstate-${var.subscription_id}"
+  name                     = "phdi-tfstate-${substr(var.subscription_id, 0, 11)}"
   resource_group_name      = var.resource_group_name
   location                 = var.location
   account_tier             = "Standard"

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -19,22 +19,18 @@ terraform {
 
 provider "azurerm" {
   features {}
-  subscription_id            = var.subscription_id
-}
-
-resource "azurerm_resource_group" "tfstate" {
-  name     = "phdi-tfstate-${var.subscription_id}"
-  location = "Central US"
+  subscription_id = var.subscription_id
 }
 
 resource "azurerm_storage_account" "tfstate" {
   name                     = "phdi-tfstate-${var.subscription_id}"
-  resource_group_name      = azurerm_resource_group.tfstate.name
-  location                 = azurerm_resource_group.tfstate.location
+  resource_group_name      = var.resource_group_name
+  location                 = var.location
   account_tier             = "Standard"
   account_kind             = "StorageV2"
   account_replication_type = "GRS"
 
   lifecycle {
     prevent_destroy = true
+  }
 }

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -18,8 +18,8 @@ terraform {
 }
 
 provider "azurerm" {
+  use_oidc = true
   features {}
-  subscription_id = var.subscription_id
 }
 
 resource "azurerm_storage_account" "tfstate" {

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -23,7 +23,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_storage_account" "tfstate" {
-  name                     = "phdi-tfstate-${substr(var.subscription_id, 0, 11)}"
+  name                     = "tfstatePHDI${substr(var.subscription_id, 0, 8)}"
   resource_group_name      = var.resource_group_name
   location                 = var.location
   account_tier             = "Standard"

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -23,7 +23,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_storage_account" "tfstate" {
-  name                     = "tfstatePHDI${substr(var.subscription_id, 0, 8)}"
+  name                     = "phditfstate${substr(var.subscription_id, 0, 8)}"
   resource_group_name      = var.resource_group_name
   location                 = var.location
   account_tier             = "Standard"

--- a/terraform/setup/outputs.tf
+++ b/terraform/setup/outputs.tf
@@ -1,3 +1,0 @@
-output "state_bucket_name" {
-  value = azurerm_storage_account.tfstate.id
-}

--- a/terraform/setup/variables.tf
+++ b/terraform/setup/variables.tf
@@ -7,7 +7,6 @@ variable "location" {
   default     = "Central US"
 }
 
-variable "zone" {
-  description = "value of the Azure zone to deploy to"
-  default     = "Zone 1"
+variable "resource_group_name" {
+  description = "value of the Azure resource group to deploy to"
 }


### PR DESCRIPTION
Resolves https://app.clickup.com/t/2yn4wdt
Resolves https://app.clickup.com/t/2yn4wrq

This updates the README and quick-start.sh script to be Azure specific. As it turns out, creating federated credentials with Azure is a lot less involved than it is for GCP! Tested locally and worked like a charm.

I also updated the terraformSetup and deployment workflows, and successfully ran a deployment to Azure!
