### PR TITLE
Enable terraform CI checks and continuous deployment

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -7,9 +7,9 @@ on:
         description: "Environment to deploy to"
         type: environment
         required: true
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Check Out Changes
         uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
 
       - name: "Azure login"
         uses: azure/login@v1

--- a/.github/workflows/terraformChecks.yaml
+++ b/.github/workflows/terraformChecks.yaml
@@ -50,6 +50,7 @@ jobs:
           done
   check-terraform-plan:
     runs-on: ubuntu-latest
+    environment: main
     defaults:
       run:
         working-directory: ./terraform/implementation

--- a/.github/workflows/terraformChecks.yaml
+++ b/.github/workflows/terraformChecks.yaml
@@ -6,17 +6,11 @@ on:
         description: "Environment to deploy to"
         type: environment
         required: true
-  # pull_request:
-  #   branches:
-  #     - "**"
-  #   paths:
-  #     - "terraform/**"
-  # push:
-  #   branches:
-  #     - main
-
-env:
-  TEST_RUNNER_TERRAFORM_VERSION: 1.2.5
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - "terraform/**"
 
 jobs:
   check-terraform-formatting:
@@ -26,9 +20,7 @@ jobs:
         working-directory: ./terraform
     steps:
       - uses: actions/checkout@v2
-      - uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: ${{env.TEST_RUNNER_TERRAFORM_VERSION}}
+      - uses: hashicorp/setup-terraform@v2
       - name: Check format
         run: terraform fmt -check -recursive
   check-terraform-validity:
@@ -41,9 +33,7 @@ jobs:
         setup implementation
     steps:
       - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 1.1.4
+      - uses: hashicorp/setup-terraform@v2
       - name: Terraform Init
         run: |
           for d in $TERRAFORM_DIRS
@@ -67,37 +57,38 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v3
+      - name: Check Out Changes
+        uses: actions/checkout@v3
 
-      - uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 1.1.4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
 
-      - id: "auth"
-        name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v0"
+      - name: "Azure login"
+        uses: azure/login@v1
         with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.SERVICE_ACCOUNT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
 
       - name: Load input variables
         env:
-          PROJECT_ID: ${{ secrets.PROJECT_ID }}
-          REGION: ${{ secrets.REGION }}
-          ZONE: ${{ secrets.ZONE }}
+          SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          LOCATION: ${{ secrets.LOCATION }}
+          RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
           SMARTY_AUTH_ID: ${{ secrets.SMARTY_AUTH_ID }}
           SMARTY_AUTH_TOKEN: ${{ secrets.SMARTY_AUTH_TOKEN }}
         run: |
-          echo project_id=\""$PROJECT_ID"\" >> terraform.tfvars
-          echo region=\""$REGION"\" >> terraform.tfvars
-          echo zone=\""$ZONE"\" >> terraform.tfvars
+          echo subscription_id=\""$SUBSCRIPTION_ID"\" >> terraform.tfvars
+          echo location=\""$LOCATION"\" >> terraform.tfvars
+          echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> terraform.tfvars
           echo smarty_auth_id=\""$SMARTY_AUTH_ID"\" >> terraform.tfvars
           echo smarty_auth_token=\""$SMARTY_AUTH_TOKEN"\" >> terraform.tfvars
-          echo bucket=\"phdi-tfstate-"$PROJECT_ID"\" >> backend.tfvars
+          echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> backend.tfvars
+          echo storage_account_name=\"phditfstate"${SUBSCRIPTION_ID:0:8}"\" >> backend.tfvars
 
       - name: Set environment
         run: |-
-          echo "ENVIRONMENT=$(
+          echo "TF_ENVIRONMENT=$(
           if "${{ github.event.inputs.environment }}"; then
             echo ${{ github.event.inputs.environment }}
           else
@@ -105,11 +96,12 @@ jobs:
           fi
           )" >> $GITHUB_ENV
 
-      - name: terraform init
-        run: terraform init -backend-config=backend.tfvars
-
-      - name: terraform workspace
-        run: terraform workspace select ${{ env.ENVIRONMENT }} || terraform workspace new ${{ env.ENVIRONMENT }}
-
-      - name: terraform plan
-        run: terraform plan
+      - name: terraform
+        env:
+          ARM_CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+        run: |
+          terraform init -backend-config=backend.tfvars
+          terraform workspace select ${{ env.TF_ENVIRONMENT }} || terraform workspace new ${{ env.TF_ENVIRONMENT }}
+          terraform plan

--- a/.github/workflows/terraformSetup.yaml
+++ b/.github/workflows/terraformSetup.yaml
@@ -19,6 +19,9 @@ jobs:
       - name: Check Out Changes
         uses: actions/checkout@v3
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
       - name: "Azure login"
         uses: azure/login@v1
         with:

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -1,3 +1,5 @@
+// Load modules here
+
 module "shared" {
   source              = "../modules/shared"
   resource_group_name = var.resource_group_name


### PR DESCRIPTION
Resolves https://app.clickup.com/t/3nfm9kh

This enables terraform CI checks on PRs with changes to the `terraform/` dir, and continuous deployment to `dev` on merge to main.