### PR TITLE
Parameterize variables, reorder activities to match pipeline order

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           terraform init -backend-config=backend.tfvars
           terraform workspace select ${{ env.TF_ENVIRONMENT }} || terraform workspace new ${{ env.TF_ENVIRONMENT }}
-          terraform apply -target="module.shared.azurerm_container_registry.phdi_registry" -target="module.shared.azurerm_user_assigned_identity.pipeline_runner" -target="module.shared.azurerm_storage_account.phi" -target="module.shared.azurerm_storage_share.tables" -auto-approve -lock-timeout=30m
+          terraform apply -target="module.shared.azurerm_container_registry.phdi_registry" -target="module.shared.azurerm_user_assigned_identity.pipeline_runner" -target="module.shared.azurerm_storage_account.phi" -target="module.shared.azurerm_storage_share.tables" -target="module.shared.azurerm_key_vault_secret.salt" -auto-approve -lock-timeout=30m
           head -n -2 terraform.tfvars >> temp.txt
           rm terraform.tfvars
           mv temp.txt terraform.tfvars
@@ -125,6 +125,7 @@ jobs:
           STORAGE_ACCOUNT_KEY=$(az storage account keys list --account-name $STORAGE_ACCOUNT_NAME --query "[0].value" -o tsv)
           STORAGE_SHARE_NAME=phdi${{ env.TF_ENVIRONMENT }}tables
           STORAGE_MOUNT_NAME=phdi${{ env.TF_ENVIRONMENT }}tables
+          HASH_SALT=$(az keyvault secret show --vault-name phdi-key-vault -n patient-hash-salt --query "value" -o tsv)
           if [[ ! $(az containerapp env show -n ${{ env.TF_ENVIRONMENT }}) ]]; then
             az containerapp env create \
               --name ${{ env.TF_ENVIRONMENT }} \
@@ -156,7 +157,7 @@ jobs:
               --registry-username $REGISTRY_NAME \
               --registry-password $REGISTRY_PASSWORD \
               --user-assigned $MANAGED_IDENTITY_ID \
-              --env-vars AUTH_ID="${{ secrets.SMARTY_AUTH_ID }}" AUTH_TOKEN="${{ secrets.SMARTY_AUTH_TOKEN }}" AZURE_CLIENT_ID="$MANAGED_IDENTITY_CLIENT_ID" AZURE_TENANT_ID="$TENANT_ID" AZURE_SUBSCRIPTION_ID="$SUBSCRIPTION_ID" STORAGE_ACCOUNT_URL="$STORAGE_ACCOUNT_URL"
+              --env-vars AUTH_ID="${{ secrets.SMARTY_AUTH_ID }}" AUTH_TOKEN="${{ secrets.SMARTY_AUTH_TOKEN }}" AZURE_CLIENT_ID="$MANAGED_IDENTITY_CLIENT_ID" AZURE_TENANT_ID="$TENANT_ID" AZURE_SUBSCRIPTION_ID="$SUBSCRIPTION_ID" STORAGE_ACCOUNT_URL="$STORAGE_ACCOUNT_URL" SALT_STR="$HASH_SALT"
           fi
           if [[ ! $(az containerapp show -n phdi-${{ env.TF_ENVIRONMENT }}-tabulation) ]]; then
             az containerapp create \

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -19,7 +19,6 @@ module "data_factory" {
   phi_storage_account_endpoint_url        = module.shared.phi_storage_account_endpoint_url
   pipeline_runner_id                      = module.shared.pipeline_runner_id
   pipeline_runner_principal_id            = module.shared.pipeline_runner_principal_id
-  hash_salt                               = module.shared.hash_salt
   fhir_upload_failures_container_name     = module.shared.fhir_upload_failures_container_name
   fhir_conversion_failures_container_name = module.shared.fhir_conversion_failures_container_name
 }

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -10,15 +10,18 @@ module "shared" {
 
 
 module "data_factory" {
-  source                           = "../modules/data_factory"
-  resource_group_name              = var.resource_group_name
-  location                         = var.location
-  fhir_converter_url               = var.fhir_converter_url
-  ingestion_container_url          = var.ingestion_container_url
-  fhir_server_url                  = "https://${module.shared.fhir_server_name}.azurehealthcareapis.com/"
-  phi_storage_account_endpoint_url = module.shared.phi_storage_account_endpoint_url
-  pipeline_runner_id               = module.shared.pipeline_runner_id
-  pipeline_runner_principal_id     = module.shared.pipeline_runner_principal_id
+  source                                  = "../modules/data_factory"
+  resource_group_name                     = var.resource_group_name
+  location                                = var.location
+  fhir_converter_url                      = var.fhir_converter_url
+  ingestion_container_url                 = var.ingestion_container_url
+  fhir_server_url                         = "https://${module.shared.fhir_server_name}.azurehealthcareapis.com/"
+  phi_storage_account_endpoint_url        = module.shared.phi_storage_account_endpoint_url
+  pipeline_runner_id                      = module.shared.pipeline_runner_id
+  pipeline_runner_principal_id            = module.shared.pipeline_runner_principal_id
+  hash_salt                               = module.shared.hash_salt
+  fhir_upload_failures_container_name     = module.shared.fhir_upload_failures_container_name
+  fhir_conversion_failures_container_name = module.shared.fhir_conversion_failures_container_name
 }
 
 

--- a/terraform/modules/data_factory/ingestion-pipeline.json
+++ b/terraform/modules/data_factory/ingestion-pipeline.json
@@ -164,7 +164,7 @@
                     "url": "${ingestion_container_url}/fhir/linkage/link/add_patient_identifier_in_bundle",
                     "method": "POST",
                     "body": {
-                        "value": "{\n    \"bundle\":@{activity('geocode').output.bundle},\n    \"salt_str\" : \"${hash_salt}\"\n}    ",
+                        "value": "{\n    \"bundle\":@{activity('geocode').output.bundle},\n}",
                         "type": "Expression"
                     }
                 }

--- a/terraform/modules/data_factory/ingestion-pipeline.json
+++ b/terraform/modules/data_factory/ingestion-pipeline.json
@@ -3,6 +3,57 @@
     "properties": {
         "activities": [
             {
+                "name": "convert_to_fhir",
+                "description": "Convert message from Hl7 or CCD to FHIR.\n",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "url": "${fhir_converter_url}/convert-to-fhir",
+                    "method": "POST",
+                    "body": {
+                        "value": "{\n    \"input_data\": @{pipeline().parameters.message},\n    \"input_type\": \"@{pipeline().parameters.message_type}\",\n    \"root_template\": \"@{pipeline().parameters.root_template}\"\n}",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "log_fhir_conversion_failure",
+                "description": "Write FHIR conversion failures to storage.\n",
+                "type": "WebActivity",
+                "dependsOn": [
+                    {
+                        "activity": "convert_to_fhir",
+                        "dependencyConditions": [
+                            "Failed"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "url": "${ingestion_container_url}/cloud/storage/write_blob_to_storage",
+                    "method": "POST",
+                    "body": {
+                        "value": "{\n    \"blob\": @{activity('convert_to_fhir').output.response},\n    \"cloud_provider\": \"azure\",\n    \"bucket_name\": \"${fhir_conversion_failures_container_name}\",\n    \"file_name\": \"@{pipeline().parameters.filename}\"\n}",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
                 "name": "standardize_name",
                 "description": "Standardize patient name.",
                 "type": "WebActivity",
@@ -113,58 +164,7 @@
                     "url": "${ingestion_container_url}/fhir/linkage/link/add_patient_identifier_in_bundle",
                     "method": "POST",
                     "body": {
-                        "value": "{\n    \"bundle\":@{activity('geocode').output.bundle},\n    \"salt_str\" : \"some-dummy-salt\"\n}    ",
-                        "type": "Expression"
-                    }
-                }
-            },
-            {
-                "name": "convert_to_fhir",
-                "description": "Convert message from Hl7 or CCD to FHIR.\n",
-                "type": "WebActivity",
-                "dependsOn": [],
-                "policy": {
-                    "timeout": "0.12:00:00",
-                    "retry": 0,
-                    "retryIntervalInSeconds": 30,
-                    "secureOutput": false,
-                    "secureInput": false
-                },
-                "userProperties": [],
-                "typeProperties": {
-                    "url": "${fhir_converter_url}/convert-to-fhir",
-                    "method": "POST",
-                    "body": {
-                        "value": "{\n    \"input_data\": @{pipeline().parameters.message},\n    \"input_type\": \"@{pipeline().parameters.message_type}\",\n    \"root_template\": \"@{pipeline().parameters.root_template}\"\n}",
-                        "type": "Expression"
-                    }
-                }
-            },
-            {
-                "name": "log_fhir_conversion_failure",
-                "description": "Write FHIR conversion failures to storage.\n",
-                "type": "WebActivity",
-                "dependsOn": [
-                    {
-                        "activity": "convert_to_fhir",
-                        "dependencyConditions": [
-                            "Failed"
-                        ]
-                    }
-                ],
-                "policy": {
-                    "timeout": "0.12:00:00",
-                    "retry": 0,
-                    "retryIntervalInSeconds": 30,
-                    "secureOutput": false,
-                    "secureInput": false
-                },
-                "userProperties": [],
-                "typeProperties": {
-                    "url": "${ingestion_container_url}/cloud/storage/write_blob_to_storage",
-                    "method": "POST",
-                    "body": {
-                        "value": "{\n    \"blob\": @{activity('convert_to_fhir').output.response},\n    \"cloud_provider\": \"azure\",\n    \"bucket_name\": \"fhir-conversion-failures\",\n    \"file_name\": \"@{pipeline().parameters.filename}\"\n}",
+                        "value": "{\n    \"bundle\":@{activity('geocode').output.bundle},\n    \"salt_str\" : \"${hash_salt}\"\n}    ",
                         "type": "Expression"
                     }
                 }
@@ -222,7 +222,7 @@
                     "url": "${ingestion_container_url}/cloud/storage/write_blob_to_storage",
                     "method": "POST",
                     "body": {
-                        "value": "{\n    \"blob\": @{activity('upload_fhir_bundle').output.fhir_server_response_body},\n    \"cloud_provider\": \"azure\",\n    \"bucket_name\": \"fhir-upload-failures\",\n    \"file_name\": \"@{pipeline().parameters.filename}\"\n}",
+                        "value": "{\n    \"blob\": @{activity('upload_fhir_bundle').output.fhir_server_response_body},\n    \"cloud_provider\": \"azure\",\n    \"bucket_name\": \"${fhir_upload_failures_container_name}\",\n    \"file_name\": \"@{pipeline().parameters.filename}\"\n}",
                         "type": "Expression"
                     }
                 }

--- a/terraform/modules/data_factory/main.tf
+++ b/terraform/modules/data_factory/main.tf
@@ -25,11 +25,10 @@ locals {
   ingestion-pipeline-config                 = jsondecode(templatefile("../modules/data_factory/ingestion-pipeline.json", {
     fhir_converter_url                      = var.fhir_converter_url,
     ingestion_container_url                 = var.ingestion_container_url,
-    fhir_server_url                         = var.fhir_server_url
-    storage_account_url                     = var.phi_storage_account_endpoint_url
-    hash_salt                               = var.hash_salt
-    fhir_upload_failures_container_name     = var.fhir_upload_failures_container_name
-    fhir_conversion_failures_container_name = var.fhir_conversion_failures_container_name
+    fhir_server_url                         = var.fhir_server_url,
+    storage_account_url                     = var.phi_storage_account_endpoint_url,
+    fhir_upload_failures_container_name     = var.fhir_upload_failures_container_name,
+    fhir_conversion_failures_container_name = var.fhir_conversion_failures_container_name,
   }))
 }
 

--- a/terraform/modules/data_factory/main.tf
+++ b/terraform/modules/data_factory/main.tf
@@ -22,11 +22,14 @@ resource "azurerm_data_factory" "phdi_data_factory" {
   }
 }
 locals {
-  ingestion-pipeline-config = jsondecode(templatefile("../modules/data_factory/ingestion-pipeline.json", {
-    fhir_converter_url      = var.fhir_converter_url,
-    ingestion_container_url = var.ingestion_container_url,
-    fhir_server_url         = var.fhir_server_url
-    storage_account_url     = var.phi_storage_account_endpoint_url
+  ingestion-pipeline-config                 = jsondecode(templatefile("../modules/data_factory/ingestion-pipeline.json", {
+    fhir_converter_url                      = var.fhir_converter_url,
+    ingestion_container_url                 = var.ingestion_container_url,
+    fhir_server_url                         = var.fhir_server_url
+    storage_account_url                     = var.phi_storage_account_endpoint_url
+    hash_salt                               = var.hash_salt
+    fhir_upload_failures_container_name     = var.fhir_upload_failures_container_name
+    fhir_conversion_failures_container_name = var.fhir_conversion_failures_container_name
   }))
 }
 

--- a/terraform/modules/data_factory/main.tf
+++ b/terraform/modules/data_factory/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_data_factory" "phdi_data_factory" {
   }
 }
 locals {
-  ingestion-pipeline-config                 = jsondecode(templatefile("../modules/data_factory/ingestion-pipeline.json", {
+  ingestion-pipeline-config = jsondecode(templatefile("../modules/data_factory/ingestion-pipeline.json", {
     fhir_converter_url                      = var.fhir_converter_url,
     ingestion_container_url                 = var.ingestion_container_url,
     fhir_server_url                         = var.fhir_server_url,

--- a/terraform/modules/data_factory/variables.tf
+++ b/terraform/modules/data_factory/variables.tf
@@ -37,3 +37,18 @@ variable "pipeline_runner_principal_id" {
   type        = string
   description = "Principal ID of the pipeline runner identity"
 }
+
+variable "hash_salt" {
+  type        = string
+  description = "Salt for patient hash"
+}
+
+variable "fhir_upload_failures_container_name" {
+  type        = string
+  description = "Container name for failed FHIR uploads"
+}
+
+variable "fhir_conversion_failures_container_name" {
+  type        = string
+  description = "Container name for failed FHIR conversions"
+}

--- a/terraform/modules/data_factory/variables.tf
+++ b/terraform/modules/data_factory/variables.tf
@@ -38,11 +38,6 @@ variable "pipeline_runner_principal_id" {
   description = "Principal ID of the pipeline runner identity"
 }
 
-variable "hash_salt" {
-  type        = string
-  description = "Salt for patient hash"
-}
-
 variable "fhir_upload_failures_container_name" {
   type        = string
   description = "Container name for failed FHIR uploads"

--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -25,12 +25,12 @@ resource "azurerm_storage_container" "source_data" {
   storage_account_name = azurerm_storage_account.phi.name
 }
 
-resource "azurerm_storage_container" "fhir_conversion_failures" {
+resource "azurerm_storage_container" "fhir_conversion_failures_container_name" {
   name                 = "fhir-conversion-failures"
   storage_account_name = azurerm_storage_account.phi.name
 }
 
-resource "azurerm_storage_container" "fhir_upload_failures" {
+resource "azurerm_storage_container" "fhir_upload_failures_container_name" {
   name                 = "fhir-upload-failures"
   storage_account_name = azurerm_storage_account.phi.name
 }

--- a/terraform/modules/shared/outputs.tf
+++ b/terraform/modules/shared/outputs.tf
@@ -30,10 +30,6 @@ output "pipeline_runner_principal_id" {
   value = azurerm_user_assigned_identity.pipeline_runner.principal_id
 }
 
-output "hash_salt" {
-  value = azurerm_key_vault_secret.salt.value
-}
-
 output "fhir_upload_failures_container_name" {
   value = azurerm_storage_container.fhir_upload_failures_container_name.name
 }

--- a/terraform/modules/shared/outputs.tf
+++ b/terraform/modules/shared/outputs.tf
@@ -29,3 +29,15 @@ output "pipeline_runner_client_id" {
 output "pipeline_runner_principal_id" {
   value = azurerm_user_assigned_identity.pipeline_runner.principal_id
 }
+
+output "hash_salt" {
+  value = azurerm_key_vault_secret.salt.value
+}
+
+output "fhir_upload_failures_container_name" {
+  value = azurerm_storage_container.fhir_upload_failures_container_name.name
+}
+
+output "fhir_conversion_failures_container_name" {
+  value = azurerm_storage_container.fhir_conversion_failures_container_name.name
+}


### PR DESCRIPTION
Hash salt, upload failure bucket name, and conversion failure bucket name are all parameterized

Activity order in ingestion-pipeline.json now matches the actual job order in the pipeline.