### PR TITLE
Add a Container App for the phdi-alerts image

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -201,8 +201,8 @@ jobs:
               --name phdi-$TF_ENV-tabulation \
               --resource-group $RESOURCE_GROUP_NAME \
               --output yaml > tabulation.yaml
-            yq -i '.properties.template += {"volumes": [{"name":"phdi${TF_ENV}tables","storageName":"phdi${TF_ENV}tables","storageType":"AzureFile"}]}' tabulation.yaml
-            yq -i '.properties.template.containers[0] += {"volumeMounts": [{"volumeName":"phdi${TF_ENV}tables", "mountPath":"/tables"}]}' tabulation.yaml
+            yq -i ".properties.template += {\"volumes\": [{\"name\":\"phdi${TF_ENV}tables\",\"storageName\":\"phdi${TF_ENV}tables\",\"storageType\":\"AzureFile\"}]}" tabulation.yaml
+            yq -i ".properties.template.containers[0] += {\"volumeMounts\": [{\"volumeName\":\"phdi${TF_ENV}tables\", \"mountPath\":\"/tables\"}]}"" tabulation.yaml
             az containerapp env storage set \
               --access-mode ReadWrite \
               --azure-file-account-name $STORAGE_ACCOUNT_NAME \

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -59,23 +59,28 @@ jobs:
           echo ingestion_container_url=\"""\" >> terraform.tfvars
 
       - name: Set environment
+        id: set-environment
+        env:
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
         run: |-
-          echo "TF_ENVIRONMENT=$(
+          echo "tf_env=$(
           if "${{ github.event.inputs.environment }}"; then
             echo ${{ github.event.inputs.environment }}
           else
             echo dev
           fi
-          )" >> $GITHUB_ENV
+          )" >> $GITHUB_OUTPUT
+          echo "short_cid=${CLIENT_ID:0:8}" >> $GITHUB_OUTPUT
 
       - name: Create container registry, managed identity, and PHI storage account
         env:
           ARM_CLIENT_ID: ${{ secrets.CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          TF_ENV: ${{ steps.set-environment.outputs.tf_env }}
         run: |
           terraform init -backend-config=backend.tfvars
-          terraform workspace new ${{ env.TF_ENVIRONMENT }} || terraform workspace select ${{ env.TF_ENVIRONMENT }}
+          terraform workspace new $TF_ENV || terraform workspace select $TF_ENV
           terraform apply -target="module.shared.azurerm_container_registry.phdi_registry" -target="module.shared.azurerm_user_assigned_identity.pipeline_runner" -target="module.shared.azurerm_storage_account.phi" -target="module.shared.azurerm_storage_share.tables" -target="module.shared.azurerm_key_vault.phdi_key_vault" -target="module.shared.random_uuid.salt" -target="module.shared.azurerm_key_vault_secret.salt" -auto-approve -lock-timeout=30m
           head -n -2 terraform.tfvars >> temp.txt
           rm terraform.tfvars
@@ -90,14 +95,18 @@ jobs:
 
       - name: Push container images to Azure Container Registry
         env:
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          TF_ENV: ${{ steps.set-environment.outputs.tf_env }}
+          SHORT_CID: ${{ steps.set-environment.outputs.short_cid }}
         run: |
-          az acr login --name phdi${{ env.TF_ENVIRONMENT }}registry${CLIENT_ID:0:8}
-          IMAGES=('fhir-converter' 'phdi-ingestion' 'phdi-tabulation')
+          REGISTRY_NAME=phdi${TF_ENV}registry${SHORT_CID}
+          az acr login --name $REGISTRY_NAME
+          IMAGES=('fhir-converter' 'phdi-ingestion' 'phdi-tabulation' 'phdi-alerts')
           for IMAGE in "${IMAGES[@]}"; do
-            docker pull ghcr.io/cdcgov/phdi/$IMAGE:main
-            docker tag ghcr.io/cdcgov/phdi/$IMAGE:main phdi${{ env.TF_ENVIRONMENT }}registry${CLIENT_ID:0:8}.azurecr.io/phdi/$IMAGE:latest
-            docker push phdi${{ env.TF_ENVIRONMENT }}registry${CLIENT_ID:0:8}.azurecr.io/phdi/$IMAGE:latest
+            GH_IMAGE_NAME=ghcr.io/cdcgov/phdi/$IMAGE:main
+            AZURE_IMAGE_NAME=$REGISTRY_NAME.azurecr.io/phdi/$IMAGE:latest
+            docker pull $GH_IMAGE_NAME
+            docker tag $GH_IMAGE_NAME $AZURE_IMAGE_NAME
+            docker push $AZURE_IMAGE_NAME
           done
       - name: "Setup yq"
         uses: dcarbone/install-yq-action@v1.0.0
@@ -111,29 +120,30 @@ jobs:
           RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
           SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
           TENANT_ID: ${{ secrets.TENANT_ID }}
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          TF_ENV: ${{ steps.set-environment.outputs.tf_env }}
+          SHORT_CID: ${{ steps.set-environment.outputs.short_cid }}
         run: |
           az config set defaults.location=$LOCATION defaults.group=$RESOURCE_GROUP_NAME
           az extension add --name containerapp --upgrade
           az provider register --namespace Microsoft.App
           az provider register --namespace Microsoft.OperationalInsights
-          REGISTRY_NAME=phdi${{ env.TF_ENVIRONMENT }}registry${CLIENT_ID:0:8}
+          REGISTRY_NAME=phdi${TF_ENV}registry${SHORT_CID}
           REGISTRY_PASSWORD=$(az acr credential show -n $REGISTRY_NAME --query "passwords[0].value" -o tsv)
           REGISTRY_URL=$(az acr show -n $REGISTRY_NAME --query "loginServer" -o tsv)
-          MANAGED_IDENTITY_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/phdi-${{ env.TF_ENVIRONMENT }}-pipeline-runner"
+          MANAGED_IDENTITY_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/phdi-$TF_ENV-pipeline-runner"
           MANAGED_IDENTITY_CLIENT_ID=$(az identity show --ids $MANAGED_IDENTITY_ID --query "clientId" -o tsv)
-          STORAGE_ACCOUNT_NAME=$(az storage account list --query "[?contains(name,'phdi${{ env.TF_ENVIRONMENT }}phi')] | [0].name" -o tsv)
-          STORAGE_ACCOUNT_URL=$(az storage account list --query "[?contains(name,'phdi${{ env.TF_ENVIRONMENT }}phi')] | [0] | primaryEndpoints.blob" -o tsv)
+          STORAGE_ACCOUNT_NAME=$(az storage account list --query "[?contains(name,'phdi${TF_ENV}phi')] | [0].name" -o tsv)
+          STORAGE_ACCOUNT_URL=$(az storage account list --query "[?contains(name,'phdi${TF_ENV}phi')] | [0] | primaryEndpoints.blob" -o tsv)
           STORAGE_ACCOUNT_KEY=$(az storage account keys list --account-name $STORAGE_ACCOUNT_NAME --query "[0].value" -o tsv)
-          STORAGE_SHARE_NAME=phdi${{ env.TF_ENVIRONMENT }}tables
-          STORAGE_MOUNT_NAME=phdi${{ env.TF_ENVIRONMENT }}tables
-          HASH_SALT=$(az keyvault secret show --vault-name ${{ env.TF_ENVIRONMENT }}vault${CLIENT_ID:0:8} -n patient-hash-salt --query "value" -o tsv)
-          if [[ ! $(az containerapp env show -n ${{ env.TF_ENVIRONMENT }}) ]]; then
+          STORAGE_SHARE_NAME=phdi${TF_ENV}tables
+          HASH_SALT=$(az keyvault secret show --vault-name ${TF_ENV}vault${SHORT_CID} -n patient-hash-salt --query "value" -o tsv)
+          COMMUNICATION_SERVICE_NAME="${TF_ENV}communication${SHORT_CID}"
+          if [[ ! $(az containerapp env show -n $TF_ENV) ]]; then
             az containerapp env create \
-              --name ${{ env.TF_ENVIRONMENT }} \
+              --name $TF_ENV \
               --resource-group $RESOURCE_GROUP_NAME \
               --location $LOCATION
-            ENV_PROVISIONED=$(az containerapp env show -n ${{ env.TF_ENVIRONMENT }} --query "properties.provisioningState" -o tsv)
+            ENV_PROVISIONED=$(az containerapp env show -n $TF_ENV --query "properties.provisioningState" -o tsv)
             CHECK_COUNT=0
             while [ $ENV_PROVISIONED != "Succeeded" ]; do
                 if [ $CHECK_COUNT -gt 60 ]; then
@@ -143,14 +153,14 @@ jobs:
                 echo "Environment not yet provisioned. Checking again in 10 seconds..."
                 sleep 10
                 CHECK_COUNT=$((CHECK_COUNT+1))
-                ENV_PROVISIONED=$(az containerapp env show -n ${{ env.TF_ENVIRONMENT }} --query "properties.provisioningState" -o tsv)
+                ENV_PROVISIONED=$(az containerapp env show -n $TF_ENV --query "properties.provisioningState" -o tsv)
             done
           fi
-          if [[ ! $(az containerapp show -n phdi-${{ env.TF_ENVIRONMENT }}-fhir-converter) ]]; then
+          if [[ ! $(az containerapp show -n phdi-$TF_ENV-fhir-converter) ]]; then
             az containerapp create \
-              --name phdi-${{ env.TF_ENVIRONMENT }}-fhir-converter \
+              --name phdi-$TF_ENV-fhir-converter \
               --resource-group $RESOURCE_GROUP_NAME \
-              --environment ${{ env.TF_ENVIRONMENT }} \
+              --environment $TF_ENV \
               --image $REGISTRY_URL/phdi/fhir-converter:latest \
               --target-port 8080 \
               --ingress 'external' \
@@ -159,11 +169,11 @@ jobs:
               --registry-password $REGISTRY_PASSWORD \
               --user-assigned $MANAGED_IDENTITY_ID 
           fi
-          if [[ ! $(az containerapp show -n phdi-${{ env.TF_ENVIRONMENT }}-ingestion) ]]; then
+          if [[ ! $(az containerapp show -n phdi-$TF_ENV-ingestion) ]]; then
             az containerapp create \
-              --name phdi-${{ env.TF_ENVIRONMENT }}-ingestion \
+              --name phdi-$TF_ENV-ingestion \
               --resource-group $RESOURCE_GROUP_NAME \
-              --environment ${{ env.TF_ENVIRONMENT }} \
+              --environment $TF_ENV \
               --image $REGISTRY_URL/phdi/phdi-ingestion:latest \
               --target-port 8080 \
               --ingress 'external' \
@@ -173,11 +183,11 @@ jobs:
               --user-assigned $MANAGED_IDENTITY_ID \
               --env-vars AUTH_ID="${{ secrets.SMARTY_AUTH_ID }}" AUTH_TOKEN="${{ secrets.SMARTY_AUTH_TOKEN }}" AZURE_CLIENT_ID="$MANAGED_IDENTITY_CLIENT_ID" AZURE_TENANT_ID="$TENANT_ID" AZURE_SUBSCRIPTION_ID="$SUBSCRIPTION_ID" STORAGE_ACCOUNT_URL="$STORAGE_ACCOUNT_URL" SALT_STR="$HASH_SALT"
           fi
-          if [[ ! $(az containerapp show -n phdi-${{ env.TF_ENVIRONMENT }}-tabulation) ]]; then
+          if [[ ! $(az containerapp show -n phdi-$TF_ENV-tabulation) ]]; then
             az containerapp create \
-              --name phdi-${{ env.TF_ENVIRONMENT }}-tabulation \
+              --name phdi-$TF_ENV-tabulation \
               --resource-group $RESOURCE_GROUP_NAME \
-              --environment ${{ env.TF_ENVIRONMENT }} \
+              --environment $TF_ENV \
               --image $REGISTRY_URL/phdi/phdi-tabulation:latest \
               --target-port 8080 \
               --ingress 'external' \
@@ -187,29 +197,46 @@ jobs:
               --user-assigned $MANAGED_IDENTITY_ID \
               --env-vars AZURE_CLIENT_ID="$MANAGED_IDENTITY_CLIENT_ID" AZURE_TENANT_ID="$TENANT_ID" AZURE_SUBSCRIPTION_ID="$SUBSCRIPTION_ID" STORAGE_ACCOUNT_URL="$STORAGE_ACCOUNT_URL"
             az containerapp show \
-              --name phdi-${{ env.TF_ENVIRONMENT }}-tabulation \
+              --name phdi-$TF_ENV-tabulation \
               --resource-group $RESOURCE_GROUP_NAME \
               --output yaml > tabulation.yaml
-            yq -i '.properties.template += {"volumes": [{"name":"phdi${{ env.TF_ENVIRONMENT }}tables","storageName":"phdi${{ env.TF_ENVIRONMENT }}tables","storageType":"AzureFile"}]}' tabulation.yaml
-            yq -i '.properties.template.containers[0] += {"volumeMounts": [{"volumeName":"phdi${{ env.TF_ENVIRONMENT }}tables", "mountPath":"/tables"}]}' tabulation.yaml
+            yq -i '.properties.template += {"volumes": [{"name":"phdi${TF_ENV}tables","storageName":"phdi${TF_ENV}tables","storageType":"AzureFile"}]}' tabulation.yaml
+            yq -i '.properties.template.containers[0] += {"volumeMounts": [{"volumeName":"phdi${TF_ENV}tables", "mountPath":"/tables"}]}' tabulation.yaml
             az containerapp env storage set \
               --access-mode ReadWrite \
               --azure-file-account-name $STORAGE_ACCOUNT_NAME \
               --azure-file-account-key $STORAGE_ACCOUNT_KEY \
               --azure-file-share-name $STORAGE_SHARE_NAME \
-              --storage-name $STORAGE_MOUNT_NAME \
-              --name ${{ env.TF_ENVIRONMENT }} \
+              --storage-name $STORAGE_SHARE_NAME \
+              --name $TF_ENV \
               --resource-group $RESOURCE_GROUP_NAME
             az containerapp update \
-              --name phdi-${{ env.TF_ENVIRONMENT }}-tabulation \
+              --name phdi-$TF_ENV-tabulation \
               --resource-group $RESOURCE_GROUP_NAME \
               --yaml tabulation.yaml
           fi
+          if [[ ! $(az containerapp show -n phdi-$TF_ENV-alerts) ]]; then
+            az containerapp create \
+              --name phdi-$TF_ENV-alerts \
+              --resource-group $RESOURCE_GROUP_NAME \
+              --environment $TF_ENV \
+              --image $REGISTRY_URL/phdi/phdi-alerts:latest \
+              --target-port 8080 \
+              --ingress 'external' \
+              --registry-server $REGISTRY_URL \
+              --registry-username $REGISTRY_NAME \
+              --registry-password $REGISTRY_PASSWORD \
+              --user-assigned $MANAGED_IDENTITY_ID \ 
+              --env-vars AZURE_CLIENT_ID="$MANAGED_IDENTITY_CLIENT_ID" AZURE_TENANT_ID="$TENANT_ID" AZURE_SUBSCRIPTION_ID="$SUBSCRIPTION_ID" COMMUNICATION_SERVICE_NAME="$COMMUNICATION_SERVICE_NAME"
+          fi
       - name: load container urls
+        env:
+          TF_ENV: ${{ steps.set-environment.outputs.tf_env }}
+          SHORT_CID: ${{ steps.set-environment.outputs.short_cid }}
         run: |
-          FHIR_CONVERTER_URL="https://$(az containerapp show --name "phdi-${{ env.TF_ENVIRONMENT }}-fhir-converter" --query "properties.configuration.ingress.fqdn" -o tsv)"
-          INGESTION_CONTAINER_URL="https://$(az containerapp show --name "phdi-${{env.TF_ENVIRONMENT}}-ingestion" --query "properties.configuration.ingress.fqdn" -o tsv)"
-          TABULATE_CONTAINER_URL="https://$(az containerapp show --name "phdi-${{env.TF_ENVIRONMENT}}-tabulation" --query "properties.configuration.ingress.fqdn" -o tsv)"
+          FHIR_CONVERTER_URL="https://$(az containerapp show --name "phdi-$TF_ENV-fhir-converter" --query "properties.configuration.ingress.fqdn" -o tsv)"
+          INGESTION_CONTAINER_URL="https://$(az containerapp show --name "phdi-$TF_ENV-ingestion" --query "properties.configuration.ingress.fqdn" -o tsv)"
+          TABULATE_CONTAINER_URL="https://$(az containerapp show --name "phdi-$TF_ENV-tabulation" --query "properties.configuration.ingress.fqdn" -o tsv)"
           echo fhir_converter_url=\""$FHIR_CONVERTER_URL"\" >> terraform.tfvars
           echo ingestion_container_url=\""$INGESTION_CONTAINER_URL"\" >> terraform.tfvars
       - name: terraform
@@ -233,15 +260,19 @@ jobs:
 
       - name: Get publish profile
         env:
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          TF_ENV: ${{ steps.set-environment.outputs.tf_env }}
+          SHORT_CID: ${{ steps.set-environment.outputs.short_cid }}
         run: |
           echo 'PUBLISH_PROFILE<<EOF' >> $GITHUB_ENV
-          az functionapp deployment list-publishing-profiles --name ${{ env.TF_ENVIRONMENT }}-read-source-data-${CLIENT_ID:0:8} --xml >> $GITHUB_ENV
+          az functionapp deployment list-publishing-profiles --name $TF_ENV-read-source-data-$SHORT_CID --xml >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
 
       - name: "Run Azure Functions Action"
         uses: Azure/functions-action@v1
+        env:
+          TF_ENV: ${{ steps.set-environment.outputs.tf_env }}
+          SHORT_CID: ${{ steps.set-environment.outputs.short_cid }}
         with:
-          app-name: "${{ env.TF_ENVIRONMENT }}-read-source-data-${CLIENT_ID:0:8}"
+          app-name: "$TF_ENV-read-source-data-$SHORT_CID"
           package: serverless-functions
           publish-profile: ${{ env.PUBLISH_PROFILE }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -227,7 +227,7 @@ jobs:
               --registry-server $REGISTRY_URL \
               --registry-username $REGISTRY_NAME \
               --registry-password $REGISTRY_PASSWORD \
-              --user-assigned $MANAGED_IDENTITY_ID \ 
+              --user-assigned $MANAGED_IDENTITY_ID \
               --env-vars AZURE_CLIENT_ID="$MANAGED_IDENTITY_CLIENT_ID" AZURE_TENANT_ID="$TENANT_ID" AZURE_SUBSCRIPTION_ID="$SUBSCRIPTION_ID" COMMUNICATION_SERVICE_NAME="$COMMUNICATION_SERVICE_NAME"
           fi
       - name: load container urls

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -100,7 +100,7 @@ jobs:
         run: |
           REGISTRY_NAME=phdi${TF_ENV}registry${SHORT_CID}
           az acr login --name $REGISTRY_NAME
-          IMAGES=('fhir-converter' 'phdi-ingestion' 'phdi-tabulation' 'phdi-alerts')
+          IMAGES=('fhir-converter' 'phdi-ingestion' 'tabulation' 'phdi-alerts')
           for IMAGE in "${IMAGES[@]}"; do
             GH_IMAGE_NAME=ghcr.io/cdcgov/phdi/$IMAGE:main
             AZURE_IMAGE_NAME=$REGISTRY_NAME.azurecr.io/phdi/$IMAGE:latest
@@ -188,7 +188,7 @@ jobs:
               --name phdi-$TF_ENV-tabulation \
               --resource-group $RESOURCE_GROUP_NAME \
               --environment $TF_ENV \
-              --image $REGISTRY_URL/phdi/phdi-tabulation:latest \
+              --image $REGISTRY_URL/phdi/tabulation:latest \
               --target-port 8080 \
               --ingress 'external' \
               --registry-server $REGISTRY_URL \

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -202,7 +202,7 @@ jobs:
               --resource-group $RESOURCE_GROUP_NAME \
               --output yaml > tabulation.yaml
             yq -i ".properties.template += {\"volumes\": [{\"name\":\"phdi${TF_ENV}tables\",\"storageName\":\"phdi${TF_ENV}tables\",\"storageType\":\"AzureFile\"}]}" tabulation.yaml
-            yq -i ".properties.template.containers[0] += {\"volumeMounts\": [{\"volumeName\":\"phdi${TF_ENV}tables\", \"mountPath\":\"/tables\"}]}"" tabulation.yaml
+            yq -i ".properties.template.containers[0] += {\"volumeMounts\": [{\"volumeName\":\"phdi${TF_ENV}tables\", \"mountPath\":\"/tables\"}]}" tabulation.yaml
             az containerapp env storage set \
               --access-mode ReadWrite \
               --azure-file-account-name $STORAGE_ACCOUNT_NAME \

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -130,7 +130,8 @@ jobs:
           REGISTRY_NAME=phdi${TF_ENV}registry${SHORT_CID}
           REGISTRY_PASSWORD=$(az acr credential show -n $REGISTRY_NAME --query "passwords[0].value" -o tsv)
           REGISTRY_URL=$(az acr show -n $REGISTRY_NAME --query "loginServer" -o tsv)
-          MANAGED_IDENTITY_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/phdi-$TF_ENV-pipeline-runner"
+          MANAGED_IDENTITY_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/phdi-${TF_ENV}-pipeline-runner"
+          echo $MANAGED_IDENTITY_ID
           MANAGED_IDENTITY_CLIENT_ID=$(az identity show --ids $MANAGED_IDENTITY_ID --query "clientId" -o tsv)
           STORAGE_ACCOUNT_NAME=$(az storage account list --query "[?contains(name,'phdi${TF_ENV}phi')] | [0].name" -o tsv)
           STORAGE_ACCOUNT_URL=$(az storage account list --query "[?contains(name,'phdi${TF_ENV}phi')] | [0] | primaryEndpoints.blob" -o tsv)

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -143,7 +143,7 @@ if gum confirm "Have you already forked or copied the $(pink 'phdi-azure') repos
   echo "Please choose repository you would like to use:"
   echo
   REPO_NAME=$(gh repo list $ORG_NAME --json name --jq ".[].name" | gum choose)
-  GITHUB_REPO="${GITHUB_USER}/${REPO_NAME}"
+  GITHUB_REPO="${ORG_NAME}/${REPO_NAME}"
 else
   # Repo needs to be created
   GITHUB_REPO="${ORG_NAME}/phdi-azure"

--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -168,10 +168,18 @@ resource "azurerm_healthcare_service" "fhir_server" {
   }
 }
 
-#### User Assigned Identity ####
+##### User Assigned Identity #####
 
 resource "azurerm_user_assigned_identity" "pipeline_runner" {
   location            = var.location
   name                = "phdi-${terraform.workspace}-pipeline-runner"
   resource_group_name = var.resource_group_name
+}
+
+##### Communication Service #####
+
+resource "azurerm_communication_service" "communication_service" {
+  name                = "${terraform.workspace}communication${substr(var.client_id, 0, 8)}"
+  resource_group_name = var.resource_group_name
+  data_location       = "United States"
 }


### PR DESCRIPTION
Resolves https://app.clickup.com/t/86696unrf
Depends on https://github.com/CDCgov/phdi/pull/141

This adds a step to our deployment workflow to deploy a new Container App for the phdi-alerts image. It also creates an Azure Communication Service via Terraform. For now the Container App will need to be configured manually with the proper environment variables.

I also did some refactoring of the deployment workflow to use `GITHUB_OUTPUT` to store the `TF_ENV` variable instead of `GITHUB_ENV`, so that it matches the way I do it in the end-to-end test workflow (#35). This makes VS Code have a lot fewer red squigglies.