### PR TITLE
Remove West US 2 option as it doesn't support containerapps. Add North Central

### DIFF
--- a/quick-start.sh
+++ b/quick-start.sh
@@ -57,7 +57,7 @@ enter_to_continue
 echo "Please select the $(pink 'location') you would like to deploy to."
 echo "More info: https://azure.microsoft.com/en-us/explore/global-infrastructure/geographies/#overview"
 echo
-LOCATION=$(gum choose "eastus" "eastus2" "westus" "westus2" "westus3" "southcentralus" "centralus")
+LOCATION=$(gum choose "eastus" "eastus2" "westus" "westus3" "northcentralus" "southcentralus" "centralus")
 
 echo "Please enter the $(pink 'Authorization ID') of your Smarty Street Account."
 echo "More info: https://www.smarty.com/docs/cloud/authentication"


### PR DESCRIPTION
Ran into this testing the script pre-LAC run. We had one region that didn't support container apps, so I've removed it West US 2. Also added a region that DOES support them that we were missing, North Central US.