### PR TITLE
Tighten up role assignments

### DIFF
--- a/quick-start.sh
+++ b/quick-start.sh
@@ -30,7 +30,7 @@ pink() {
 spin() {
   local -r title="${1}"
   shift 1
-  gum spin -s line --title "${title}" -- $@
+  gum spin --show-output -s line --title "${title}" -- $@
 }
 
 # Create text box

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -30,7 +30,7 @@ pink() {
 spin() {
   local -r title="${1}"
   shift 1
-  gum spin --show-output -s line --title "${title}" -- $@
+  gum spin -s line --title "${title}" -- $@
 }
 
 # Create text box

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -166,7 +166,7 @@ APP_REG_NAME=github-$RESOURCE_GROUP_NAME
 CLIENT_ID=$(az ad app create --display-name $APP_REG_NAME --query appId --output tsv)
 
 # Create service principal and grant access to subscription
-spin "Creating service principal..." az ad sp create-for-rbac --scopes /subscriptions/$SUBSCRIPTION_ID --role owner --name $APP_REG_NAME
+spin "Creating service principal..." az ad sp create-for-rbac --scopes /subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME --role owner --name $APP_REG_NAME
 
 # Create federated credential
 cat << EOF > credentials.json


### PR DESCRIPTION
This tightens up security a bit by reducing privileges on the service principal from Owner at the subscription level to Owner at the resource group level. In order to do this, a custom role with only two permissions needs to be assigned at the subscription level.