### PR TITLE
Update read source data for RR

### DIFF
--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -63,8 +63,8 @@ def main(event: func.EventGridEvent) -> None:
             container_name=container_name, filename=filename
         )
 
-        wait_time = os.environ.get("WAIT_TIME", 10)
-        sleep_time = os.environ.get("SLEEP_TIME", 1)
+        wait_time = float(os.environ.get("WAIT_TIME", 10))
+        sleep_time = float(os.environ.get("SLEEP_TIME", 1))
 
         start_time = datetime.now()
         time_elapsed = 0

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -43,7 +43,6 @@ def main(event: func.EventGridEvent) -> None:
         if any([name for name in ["RR", "html"] if name in filename_parts[1]]):
             raise Exception("Invalid file type.")
 
-
     else:
         raise Exception("Invalid file type.")
 

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -1,7 +1,7 @@
 import os
 import json
 import azure.functions as func
-
+from time import sleep
 from datetime import datetime
 from azure.core.exceptions import ResourceNotFoundError
 from azure.mgmt.datafactory import DataFactoryManagementClient
@@ -68,6 +68,7 @@ def main(event: func.EventGridEvent) -> None:
 
         start_time = datetime.now()
         time_elapsed = 0
+
         reportability_response = get_reportability_response(cloud_container_connection, container_name, filename)
         while (
             reportability_response == ""
@@ -76,8 +77,6 @@ def main(event: func.EventGridEvent) -> None:
             sleep(sleep_time)
             time_elapsed = (datetime.now() - start_time).seconds
             reportability_response = get_reportability_response(cloud_container_connection, container_name, filename)
-
-
         # Determine if we want to raise exception or log a warning TODO
         if reportability_response == "":
             raise Exception(

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -48,13 +48,15 @@ def main(event: func.EventGridEvent) -> None:
 
         if any([name for name in ["RR", "html"] if name in filename_parts[1]]):
             logging.info(
-                "The read source data function was triggered. Processing will not continue as the file uploaded was not a currently handled type."
+                "The read source data function was triggered. Processing will not "
+                "continue as the file uploaded was not a currently handled type."
             )
             return
 
     else:
         logging.warning(
-            "The read source data function was triggered. We expected a file in the elr, vxu, or ecr folders, but something else was provided."
+            "The read source data function was triggered. We expected a file in the "
+            "elr, vxu, or ecr folders, but something else was provided."
         )
         return
 
@@ -88,13 +90,16 @@ def main(event: func.EventGridEvent) -> None:
 
         if reportability_response == "":
             logging.warning(
-                "The ingestion pipeline was not triggered for this eCR, because a reportability response was not found for filename "
+                "The ingestion pipeline was not triggered for this eCR, because a "
+                "reportability response was not found for filename "
                 f"{container_name}/{filename}."
             )
             return
 
-        # For eICR, just include contents of eICR for now. TODO Determine how to incorporate RR directly in eICR when creating the message
-        # We want to import from phdi python package function to takes things from RR and adds them into the eICR where appropriate.
+        # For eICR, just include contents of eICR for now.
+        # TODO Determine how to incorporate RR directly in eICR when creating the
+        # message. We want to import from phdi python package function to takes things
+        # from RR and adds them into the eICR where appropriate.
         messages = [ecr]
 
     # Handle batch Hl7v2 messages.
@@ -159,7 +164,7 @@ def get_reportability_response(
         reportability_response = cloud_container_connection.download_object(
             container_name=container_name, filename=filename.replace("eICR", "RR")
         )
-    except ResourceNotFoundError as e:
+    except ResourceNotFoundError:
         reportability_response = ""
 
     return reportability_response

--- a/serverless-functions/requirements_dev.txt
+++ b/serverless-functions/requirements_dev.txt
@@ -1,1 +1,3 @@
 pytest
+black
+flake8

--- a/serverless-functions/tests/ReadSourceData/test_read_source_data.py
+++ b/serverless-functions/tests/ReadSourceData/test_read_source_data.py
@@ -217,7 +217,7 @@ def test_handle_ecr_with_no_rr(
     event.get_json.return_value = {
         "url": (
             "https://phdidevphi87b9f133.blob.core.windows.net/"
-            f"source-data/ecr/12345eICR.xml"
+            "source-data/ecr/12345eICR.xml"
         )
     }
 
@@ -225,7 +225,9 @@ def test_handle_ecr_with_no_rr(
     blob.name = "source-data/ecr/12345eICR.xml"
     blob.read.return_value = b"some-blob-contents"
 
-    warning_message = f"The ingestion pipeline was not triggered for this eCR, because a reportability response was not found for filename {blob.name}."
+    warning_message = "The ingestion pipeline was not triggered for this eCR, "
+    "because a reportability response was not found for filename "
+    f"{blob.name}."
 
     read_source_data(event)
     patched_logging.warning.assert_called_with(warning_message)

--- a/serverless-functions/tests/ReadSourceData/test_read_source_data.py
+++ b/serverless-functions/tests/ReadSourceData/test_read_source_data.py
@@ -225,9 +225,11 @@ def test_handle_ecr_with_no_rr(
     blob.name = "source-data/ecr/12345eICR.xml"
     blob.read.return_value = b"some-blob-contents"
 
-    warning_message = "The ingestion pipeline was not triggered for this eCR, "
-    "because a reportability response was not found for filename "
-    f"{blob.name}."
+    warning_message = (
+        "The ingestion pipeline was not triggered for this eCR, "
+        "because a reportability response was not found for filename "
+        f"{blob.name}."
+    )
 
     read_source_data(event)
     patched_logging.warning.assert_called_with(warning_message)

--- a/serverless-functions/tests/ReadSourceData/test_read_source_data.py
+++ b/serverless-functions/tests/ReadSourceData/test_read_source_data.py
@@ -179,6 +179,7 @@ def test_get_reportability_response_failure():
 
     assert get_reportability_response(cloud_container_connection, container_name, filename) == ""
 
+@mock.patch("ReadSourceData.os")
 @mock.patch("ReadSourceData.AzureCredentialManager")
 @mock.patch("ReadSourceData.AzureCloudContainerConnection")
 @mock.patch("ReadSourceData.get_reportability_response")
@@ -186,7 +187,12 @@ def test_handle_ecr_with_no_rr(
     patched_get_reportability_response,
     patched_cloud_container_connection,
     patched_azure_cred_manager,
+    patched_os
 ):
+    patched_os.environ = {
+        "WAIT_TIME": 0.1,
+        "SLEEP_TIME": 0.05
+    }
     patched_azure_cred_manager.return_value.get_credentials.return_value = (
         "some-credentials"
     )

--- a/serverless-functions/tests/ReadSourceData/test_read_source_data.py
+++ b/serverless-functions/tests/ReadSourceData/test_read_source_data.py
@@ -195,7 +195,7 @@ def test_handle_ecr_with_no_rr(
         "some-message"
     )
     
-    patched_get_reportability_response.return_value == ""
+    patched_get_reportability_response.return_value = ""
 
     event = mock.MagicMock()
     event.get_json.return_value = {
@@ -209,13 +209,10 @@ def test_handle_ecr_with_no_rr(
     blob.name = "source-data/ecr/12345eICR.xml"
     blob.read.return_value = b"some-blob-contents"
     
-
-    with pytest.raises(Exception) as e:
+    exception_message = f"The ingestion pipeline was not triggered for this eCR, because a reportability response was not found for filename {blob.name}."
+    with pytest.raises(Exception, match=exception_message ) as e:
         read_source_data(event)
-        assert str(e) == (
-                    "The ingestion pipeline was not triggered for this eCR, because a reportability response was not found for filename "
-                    f"{blob.name}."
-                )
+
 
 
 

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -36,4 +36,6 @@ module "read_source_data" {
   pipeline_runner_id        = module.shared.pipeline_runner_id
   pipeline_runner_client_id = module.shared.pipeline_runner_client_id
   client_id                 = var.client_id
+  wait_time                 = 10
+  sleep_time                = 1
 }

--- a/terraform/modules/read_source_data/main.tf
+++ b/terraform/modules/read_source_data/main.tf
@@ -56,6 +56,8 @@ resource "azurerm_linux_function_app" "read_source_data" {
     AZURE_CLIENT_ID                 = var.pipeline_runner_client_id
     AZURE_TENANT_ID                 = data.azurerm_client_config.current.tenant_id
     AZURE_SUBSCRIPTION_ID           = var.subscription_id
+    WAIT_TIME                       = var.wait_time
+    SLEEP_TIME                      = var.sleep_time
   }
 
   lifecycle {

--- a/terraform/modules/read_source_data/variables.tf
+++ b/terraform/modules/read_source_data/variables.tf
@@ -37,3 +37,13 @@ variable "client_id" {
   type        = string
   description = "Client ID of the app registration used to authenticate to Azure"
 }
+
+variable "wait_time" {
+  type        = number
+  description = "The number of seconds to wait when polling for a resource."
+}
+
+variable "sleep_time" {
+  type        = number
+  description = "The number of seconds to sleep in lookup tries for a resource."
+}


### PR DESCRIPTION
### Update ReadSourceData function to handle RRs

**Related ticket:** [Clickup link](https://app.clickup.com/t/863fz53d5)

**Proposed changes**
- ReadSourceData function:
  - Refactor code to expect a RR to be uploaded with an eICR, and read the RR if it exists. 
  - Currently, we don't do anything with the contents of the RR, this functionality will be added in a future ticket.
  - If a file uploaded to the ecr folder is an RR (or html format), we don't want to trigger the pipeline for an RR and exit execution. Eventually we will process it together with the eICR.
 
![Screen Shot 2023-02-08 at 12 44 33 PM](https://user-images.githubusercontent.com/89797785/217610166-329cff03-06d4-40f6-8413-62e01cfd96a3.png)

  - If there is no RR, instead of throwing an exception, we log a warning. Since we don't currently process RRs, it doesn't make sense to throw an exception at this time. This may change in the future depending on user needs.
  
![Screen Shot 2023-02-08 at 12 36 33 PM](https://user-images.githubusercontent.com/89797785/217608498-183066d8-f56d-408f-806a-78fd60c9bfdf.png)

  - Additional logging added for other cases, to make errors more readable in Azure
- ReadSourceData tests:
  - New case for if no RR is uploaded with an eICR
  - New case for reading RR response failure and success
  - Updated existing tests to reflect change from raising exception to logging warning/error

**Testing:** Deployed to `test`, can manually test cases 1) upload just an eICR file and 2) upload eICR + RR files