### PR TITLE
Fix issue with removing ACR docker images on second deploy

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Cache Docker images.
         uses: ScribeMD/docker-cache@0.2.7
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles(LICENSE) }}
+          key: docker-${{ runner.os }}-${{ hashFiles(./LICENSE) }}
 
       - name: Create container registry, managed identity, and PHI storage account
         env:

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Cache Docker images.
         uses: ScribeMD/docker-cache@0.2.7
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles(...) }}
+          key: docker-${{ runner.os }}-${{ hashFiles(LICENSE) }}
 
       - name: Create container registry, managed identity, and PHI storage account
         env:

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Cache Docker images.
         uses: ScribeMD/docker-cache@0.2.7
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles(./LICENSE) }}
+          key: docker-${{ runner.os }}-${{ hashFiles('**/LICENSE') }}
 
       - name: Create container registry, managed identity, and PHI storage account
         env:

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -81,6 +81,11 @@ jobs:
           )" >> $GITHUB_OUTPUT
           echo "short_cid=${CLIENT_ID:0:8}" >> $GITHUB_OUTPUT
 
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.2.7
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles(...) }}
+
       - name: Create container registry, managed identity, and PHI storage account
         env:
           ARM_CLIENT_ID: ${{ secrets.CLIENT_ID }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -81,7 +81,7 @@ jobs:
           )" >> $GITHUB_OUTPUT
           echo "short_cid=${CLIENT_ID:0:8}" >> $GITHUB_OUTPUT
 
-      - name: Cache Docker images.
+      - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.2.7
         with:
           key: docker-${{ runner.os }}-${{ hashFiles('**/LICENSE') }}

--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -184,23 +184,24 @@ data "docker_registry_image" "ghcr_data" {
 resource "docker_image" "ghcr_image" {
   for_each      = local.images
   name          = data.docker_registry_image.ghcr_data[each.key].name
+  keep_locally  = true
   pull_triggers = [data.docker_registry_image.ghcr_data[each.key].sha256_digest]
 }
 
 resource "docker_tag" "tag_for_azure" {
   for_each     = local.images
-  depends_on   = [docker_image.ghcr_image]
-  source_image = data.docker_registry_image.ghcr_data[each.key].name
+  source_image = docker_image.ghcr_image[each.key].name
   target_image = "${azurerm_container_registry.phdi_registry.login_server}/phdi/${each.key}:latest"
 }
 
 resource "docker_registry_image" "acr_image" {
-  for_each   = local.images
-  depends_on = [docker_tag.tag_for_azure]
-  name       = "${azurerm_container_registry.phdi_registry.login_server}/phdi/${each.key}:latest"
+  for_each      = local.images
+  depends_on    = [docker_tag.tag_for_azure]
+  name          = "${azurerm_container_registry.phdi_registry.login_server}/phdi/${each.key}:latest"
+  keep_remotely = true
 
   triggers = {
-    repo_digest = docker_image.ghcr_image[each.key].repo_digest
+    repo_digest = data.docker_registry_image.ghcr_data[each.key].sha256_digest
   }
 }
 

--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -201,7 +201,7 @@ resource "docker_registry_image" "acr_image" {
   keep_remotely = true
 
   triggers = {
-    repo_digest = data.docker_registry_image.ghcr_data[each.key].sha256_digest
+    sha256_digest = data.docker_registry_image.ghcr_data[each.key].sha256_digest
   }
 }
 


### PR DESCRIPTION
Followup to #50 which fixes an issue where on second deploy, terraform would remove the ACR image. This adds the `keep_remotely` key which prevents that. I also added a Docker image caching step to try to prevent repulling from GHCR on every deploy, but I don't think it can be tested until after merging to `main`.

Tested by deploying twice in a row to `dev3`, both were successful