### PR TITLE
Add message parser to pipeline

### DIFF
--- a/.github/workflows/destroy.yaml
+++ b/.github/workflows/destroy.yaml
@@ -63,6 +63,7 @@ jobs:
           echo storage_account_name=\"phditfstate"${CLIENT_ID:0:8}"\" >> backend.tfvars
           echo fhir_converter_url=\"""\" >> terraform.tfvars
           echo ingestion_container_url=\"""\" >> terraform.tfvars
+          echo message_parser_url=\"""\" >> terraform.tfvars
 
       - name: Set environment
         id: set-environment

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -15,12 +15,12 @@ module "shared" {
 
 
 module "data_factory" {
-  source                                  = "../modules/data_factory"
-  resource_group_name                     = var.resource_group_name
-  location                                = var.location
-  fhir_converter_url                      = module.shared.fhir_converter_url
-  ingestion_container_url                 = module.shared.ingestion_container_url
-  message_parser_url                      = module.shared.message_parser_url
+  source                  = "../modules/data_factory"
+  resource_group_name     = var.resource_group_name
+  location                = var.location
+  fhir_converter_url      = module.shared.fhir_converter_url
+  ingestion_container_url = module.shared.ingestion_container_url
+  message_parser_url      = module.shared.message_parser_url
   # tabulation_container_url                = module.shared.tabulation_container_url
   # alerts_container_url                    = module.shared.alerts_container_url
   fhir_server_url                         = "https://${module.shared.fhir_server_name}.azurehealthcareapis.com/"

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -15,11 +15,12 @@ module "shared" {
 
 
 module "data_factory" {
-  source                  = "../modules/data_factory"
-  resource_group_name     = var.resource_group_name
-  location                = var.location
-  fhir_converter_url      = module.shared.fhir_converter_url
-  ingestion_container_url = module.shared.ingestion_container_url
+  source                                  = "../modules/data_factory"
+  resource_group_name                     = var.resource_group_name
+  location                                = var.location
+  fhir_converter_url                      = module.shared.fhir_converter_url
+  ingestion_container_url                 = module.shared.ingestion_container_url
+  message_parser_url                      = module.shared.message_parser_url
   # tabulation_container_url                = module.shared.tabulation_container_url
   # alerts_container_url                    = module.shared.alerts_container_url
   fhir_server_url                         = "https://${module.shared.fhir_server_name}.azurehealthcareapis.com/"

--- a/terraform/modules/data_factory/ingestion-pipeline.json
+++ b/terraform/modules/data_factory/ingestion-pipeline.json
@@ -190,10 +190,10 @@
                 },
                 "userProperties": [],
                 "typeProperties": {
-                    "url": "${message_parser_url}",
+                    "url": "${message_parser_url}/parse_message",
                     "method": "POST",
                     "body": {
-                        "value": "{\n    \"message_format\": \"fhir\"\n,\n    \"parsing_schema_name\": \"ecr.json\"\n,\n    \"message\": @{activity('add_patient_hash').output.bundle}}",
+                        "value": "{\n    \"message_format\": \"fhir\",\n    \"parsing_schema_name\": \"ecr.json\",\n    \"message\": @{activity('add_patient_hash').output.bundle}\n}",
                         "type": "Expression"
                     }
                 }

--- a/terraform/modules/data_factory/ingestion-pipeline.json
+++ b/terraform/modules/data_factory/ingestion-pipeline.json
@@ -193,10 +193,8 @@
                     "url": "${message_parser_url}",
                     "method": "POST",
                     "body": {
-                        "body": {
-                            "value": "{\n    \"message_format\": \"fhir\"\n,\n    \"parsing_schema_name\": \"ecr.json\"\n,\n    \"message\": @{activity('add_patient_hash').output.bundle}}",
-                            "type": "Expression"
-                        }
+                        "value": "{\n    \"message_format\": \"fhir\"\n,\n    \"parsing_schema_name\": \"ecr.json\"\n,\n    \"message\": @{activity('add_patient_hash').output.bundle}}",
+                        "type": "Expression"
                     }
                 }
             },

--- a/terraform/modules/data_factory/ingestion-pipeline.json
+++ b/terraform/modules/data_factory/ingestion-pipeline.json
@@ -193,8 +193,13 @@
                     "url": "${message_parser_url}",
                     "method": "POST",
                     "body": {
-                        "value": "",
-                        "type": ""
+                        "message_format": "fhir",
+                        "message_type": "ecr",
+                        "parsing_schema": {},
+                        "parsing_schema_name": "",
+                        "fhir_converter_url": "${fhir_converter_url}",
+                        "credential_manager": "azure",
+                        "message": "string"
                     }
                 }
             },

--- a/terraform/modules/data_factory/ingestion-pipeline.json
+++ b/terraform/modules/data_factory/ingestion-pipeline.json
@@ -170,6 +170,35 @@
                 }
             },
             {
+                "name": "message_parser",
+                "description": "Extract desired fields from a given healthcare message.",
+                "type": "WebActivity",
+                "dependsOn": [
+                    {
+                        "activity": "add_patient_hash",
+                        "dependencyConditions": [
+                            "Completed"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "url": "${message_parser_url}",
+                    "method": "POST",
+                    "body": {
+                        "value": "",
+                        "type": ""
+                    }
+                }
+            },
+            {
                 "name": "upload_fhir_bundle",
                 "description": "Compute a hashed identifier that can be used for record linkage.",
                 "type": "WebActivity",

--- a/terraform/modules/data_factory/ingestion-pipeline.json
+++ b/terraform/modules/data_factory/ingestion-pipeline.json
@@ -177,7 +177,7 @@
                     {
                         "activity": "add_patient_hash",
                         "dependencyConditions": [
-                            "Completed"
+                            "Succeeded"
                         ]
                     }
                 ],
@@ -193,13 +193,10 @@
                     "url": "${message_parser_url}",
                     "method": "POST",
                     "body": {
-                        "message_format": "fhir",
-                        "message_type": "ecr",
-                        "parsing_schema": {},
-                        "parsing_schema_name": "",
-                        "fhir_converter_url": "${fhir_converter_url}",
-                        "credential_manager": "azure",
-                        "message": "string"
+                        "body": {
+                            "value": "{\n    \"message_format\": \"fhir\"\n,\n    \"parsing_schema_name\": \"ecr.json\"\n,\n    \"message\": @{activity('add_patient_hash').output.bundle}}",
+                            "type": "Expression"
+                        }
                     }
                 }
             },

--- a/terraform/modules/data_factory/main.tf
+++ b/terraform/modules/data_factory/main.tf
@@ -24,9 +24,9 @@ resource "azurerm_data_factory" "phdi_data_factory" {
 locals {
   ingestion-pipeline-config = jsondecode(templatefile("../modules/data_factory/ingestion-pipeline.json", {
     fhir_converter_url                      = var.fhir_converter_url,
-    ingestion_container_url                 = var.ingestion_container_url,
-    message_parser_url                      = var.message_parser_url, 
+    ingestion_container_url                 = var.ingestion_container_url, 
     fhir_server_url                         = var.fhir_server_url,
+    message_parser_url                      = var.message_parser_url,
     storage_account_url                     = var.phi_storage_account_endpoint_url,
     fhir_upload_failures_container_name     = var.fhir_upload_failures_container_name,
     fhir_conversion_failures_container_name = var.fhir_conversion_failures_container_name,

--- a/terraform/modules/data_factory/main.tf
+++ b/terraform/modules/data_factory/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_data_factory" "phdi_data_factory" {
 locals {
   ingestion-pipeline-config = jsondecode(templatefile("../modules/data_factory/ingestion-pipeline.json", {
     fhir_converter_url                      = var.fhir_converter_url,
-    ingestion_container_url                 = var.ingestion_container_url, 
+    ingestion_container_url                 = var.ingestion_container_url,
     fhir_server_url                         = var.fhir_server_url,
     message_parser_url                      = var.message_parser_url,
     storage_account_url                     = var.phi_storage_account_endpoint_url,

--- a/terraform/modules/data_factory/main.tf
+++ b/terraform/modules/data_factory/main.tf
@@ -25,6 +25,7 @@ locals {
   ingestion-pipeline-config = jsondecode(templatefile("../modules/data_factory/ingestion-pipeline.json", {
     fhir_converter_url                      = var.fhir_converter_url,
     ingestion_container_url                 = var.ingestion_container_url,
+    message_parser_url                      = var.message_parser_url, 
     fhir_server_url                         = var.fhir_server_url,
     storage_account_url                     = var.phi_storage_account_endpoint_url,
     fhir_upload_failures_container_name     = var.fhir_upload_failures_container_name,

--- a/terraform/modules/data_factory/variables.tf
+++ b/terraform/modules/data_factory/variables.tf
@@ -18,11 +18,10 @@ variable "ingestion_container_url" {
   description = "URL of the ingestion container"
 }
 
-# TODO: Uncomment when message parser is implemented
-# variable "message_parser_url" {
-#  type        = string
-#  description = "URL of the message parser container"
-# }
+variable "message_parser_url" {
+  type        = string
+  description = "URL of the message parser container"
+}
 
 # TODO: Uncomment when validation is implemented
 # variable "validation_container_url" {

--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -370,4 +370,10 @@ resource "azurerm_postgresql_flexible_server" "mpi" {
     environment = terraform.workspace
     managed-by  = "terraform"
   }
+
+  lifecycle {
+    ignore_changes = [
+      zone
+    ]
+  }
 }


### PR DESCRIPTION
### Resolves [286](https://app.zenhub.com/workspaces/dibbs-63f7aa3e1ecdbb0011edb299/issues/gh/cdcgov/phdi/286)

### Suggested Changes
Adds tf config for adding message_parser service to the ingestion pipeline