### PR TITLE
Enable hierarchical name spaces in PHI storage account

### DIFF
--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_storage_account" "phi" {
   account_tier             = "Standard"
   account_kind             = "StorageV2"
   account_replication_type = "GRS"
-  is_hns_enabled            = true
+  is_hns_enabled           = true
 
   identity {
     type         = "UserAssigned"

--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -7,6 +7,7 @@ resource "azurerm_storage_account" "phi" {
   account_tier             = "Standard"
   account_kind             = "StorageV2"
   account_replication_type = "GRS"
+  is_hns_enabled            = true
 
   identity {
     type         = "UserAssigned"


### PR DESCRIPTION
This PR turns on hierarchical names for the PHI storage account. This will allow us to store delta tables in containers in this storage account.

fixes CDCgov/phdi#288