### PR TITLE
Add firewall rule to Postgres to allow access from Azure services

### DIFF
--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -264,6 +264,8 @@ resource "azurerm_postgresql_flexible_server_database" "mpi" {
   charset   = "utf8"
 }
 
+// Allow Azure services to access the database
+// See here: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_firewall_rule
 resource "azurerm_postgresql_firewall_rule" "allow_azure_services" {
   name                = "allow_azure_services"
   resource_group_name = var.resource_group_name


### PR DESCRIPTION
This should resolve the issue with record linkage timing out - it's timing out because the container isn't allowed to access the database.