### PR TITLE
Change Terraform backend config to use variables for use_oidc

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -64,8 +64,11 @@ jobs:
           echo object_id=\""$OBJECT_ID"\" >> terraform.tfvars
           echo ghcr_username=\""$GHCR_USERNAME"\" >> terraform.tfvars
           echo ghcr_token=\""$GHCR_TOKEN"\" >> terraform.tfvars
+          echo use_oidc=true >> terraform.tfvars
           echo resource_group_name=\""$RESOURCE_GROUP_NAME"\" >> backend.tfvars
           echo storage_account_name=\"phditfstate"${CLIENT_ID:0:8}"\" >> backend.tfvars
+          echo use_oidc=true >> backend.tfvars
+          echo use_msi=true >> backend.tfvars
           az config set defaults.location=$LOCATION defaults.group=$RESOURCE_GROUP_NAME
 
       - name: Set environment

--- a/terraform/implementation/backend.tf
+++ b/terraform/implementation/backend.tf
@@ -7,14 +7,12 @@ terraform {
   }
 
   backend "azurerm" {
-    use_oidc       = true
     container_name = "tfstate"
     key            = "prod.terraform.tfstate"
-    use_msi        = true
   }
 }
 
 provider "azurerm" {
-  use_oidc = true
+  use_oidc = var.use_oidc
   features {}
 }


### PR DESCRIPTION
I should have thought of this way sooner.

Now, just add the following to `backend.tfvars` locally:
```
use_oidc             = false
use_msi              = false
```
And this to `terraform.tfvars`:
```
use_oidc            = false
```

And you no longer have to fiddle with `backend.tf` when running locally anymore!