### PR TITLE
Add a support template

### DIFF
--- a/.github/ISSUE_TEMPLATE/support-request.md
+++ b/.github/ISSUE_TEMPLATE/support-request.md
@@ -1,0 +1,39 @@
+---
+name: Support Request
+about: Create a report to help us improve
+title: ''
+labels: 'support'
+assignees: ''
+
+---
+
+**Describe the problem**
+A clear and concise description of what the problem is or what question you have.
+
+**Impact**
+Please describe the impact this problem is causing to your program or organization.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Intended outcome**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+**NOTE**: Please make sure your screenshots do NOT contain PHI.
+If applicable, add screenshots to help explain your problem.
+
+**Logs**
+If applicable, please attach logs to help describe your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Add support template, so users of the pipeline who need assistance have a mechanism to request it.

Will create a separate PR with a support guide pointing users to this template. This is part of the work to create a handoff guide for LAC.