### PR TITLE
Change data format from parquet to delta to make Delta Table

### DIFF
--- a/scripts/Synapse/convertParquetMCI.ipynb
+++ b/scripts/Synapse/convertParquetMCI.ipynb
@@ -24,7 +24,7 @@
         "\n",
         "def insert(mci_incoming_file_path,mci_delta_table_path):\n",
         "    df = spark.read.parquet(mci_incoming_file_path)\n",
-        "    df.write.mode(\"append\").format(\"parquet\").save(mci_delta_table_path)\n",
+        "    df.write.mode(\"append\").format(\"delta\").save(mci_delta_table_path)\n",
         "    spark.read.parquet(mci_delta_table_path).show(5)\n",
         "\n",
         "insert(mci_incoming_file_path,mci_delta_table_path)"


### PR DESCRIPTION
Accidentally exported converted MCI data as parquet and not as a Delta Table. This fixes that issue!