### PR TITLE
Add @ to Synapse notebook file names

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -193,10 +193,10 @@ jobs:
           SHORT_CID: ${{ steps.set-environment.outputs.short_cid }}
         run: |
           if ! az synapse notebook show --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Convert Parquet MPI"; then
-            az synapse notebook create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Convert Parquet MPI" --file "scripts/Synapse/convertParquetMPI.ipynb"
+            az synapse notebook create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Convert Parquet MPI" --file @"scripts/Synapse/convertParquetMPI.ipynb"
           fi
           if ! az synapse notebook show --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Convert Parquet MCI"; then
-            az synapse notebook create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Convert Parquet MCI" --file "scripts/Synapse/convertParquetMCI.ipynb"
+            az synapse notebook create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Convert Parquet MCI" --file @"scripts/Synapse/convertParquetMCI.ipynb"
           fi
 
   end-to-end:


### PR DESCRIPTION
Need to follow CLI example: 
```
Examples
    Create a notebook. Pay attention to add "@" at the front of the file path as the best practice
    for complex arguments like JSON string.
        az synapse notebook create --workspace-name testsynapseworkspace \
          --name testnotebook --file @"path/notebook.ipynb" --folder-path 'folder/subfolder'
```