### PR TITLE
Add  Synapse job to update the IRIS id in the eCR datastore

### DIFF
--- a/scripts/Synapse/updateECRDataStoreIrisID.ipynb
+++ b/scripts/Synapse/updateECRDataStoreIrisID.ipynb
@@ -1,0 +1,159 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": true
+        }
+      },
+      "outputs": [],
+      "source": [
+        "pip install psycopg2-binary azure-keyvault"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false,
+          "source_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      },
+      "outputs": [],
+      "source": [
+        "from azure.identity import ManagedIdentityCredential\n",
+        "from azure.core.credentials import AccessToken\n",
+        "from azure.keyvault.secrets import SecretClient\n",
+        "import psycopg2\n",
+        "import time\n",
+        "\n",
+        "from delta.tables import *\n",
+        "from pyspark.sql.functions import *"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false,
+          "source_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      },
+      "outputs": [],
+      "source": [
+        "ECR_DELTA_TABLE_FILE_PATH = \"/delta/ecr\"\n",
+        "\n",
+        "# Set up authentication\n",
+        "class spoof_token:\n",
+        "    def get_token(*args, **kwargs):\n",
+        "        return AccessToken(\n",
+        "            token=mssparkutils.credentials.getToken(audience=\"vault\"),\n",
+        "            expires_on=int(time.time())+60*10 # some random time in future... synapse doesn't document how to get the actual time\n",
+        "        )\n",
+        "\n",
+        "credential = ManagedIdentityCredential()\n",
+        "credential._credential = spoof_token() # monkey-patch the contents of the private `_credential`\n",
+        "\n",
+        "# Set your Key Vault information\n",
+        "KEY_VAULT_URL = \"https://devvault9d194c64.vault.azure.net\"\n",
+        "DB_PASS_SECRET_NAME = \"mpi-password-test123\"\n",
+        "\n",
+        "# Create a SecretClient to interact with the Key Vault\n",
+        "secret_client = SecretClient(vault_url=KEY_VAULT_URL, credential=credential)\n",
+        "\n",
+        "# Retrieve the secret\n",
+        "db_pass_secret = secret_client.get_secret(DB_PASS_SECRET_NAME)\n",
+        "\n",
+        "# Database connection parameters\n",
+        "DB_NAME = \"DibbsMpiDB\"\n",
+        "DB_USER = \"postgres\"\n",
+        "DB_HOST = \"phdidevmpi9d194c64.postgres.database.azure.com\"\n",
+        "DB_PORT = \"5432\"\n",
+        "DB_TABLE = \"person\"\n",
+        "\n",
+        "# Get the secret value (password) from the previous step\n",
+        "db_password = db_pass_secret.value\n",
+        "\n",
+        "# Connect to the database\n",
+        "conn = psycopg2.connect(\n",
+        "    dbname=DB_NAME,\n",
+        "    user=DB_USER,\n",
+        "    password=db_password,\n",
+        "    host=DB_HOST,\n",
+        "    port=DB_PORT\n",
+        ")\n",
+        "\n",
+        "# Create a cursor\n",
+        "cur = conn.cursor()\n",
+        "\n",
+        "# Execute the query to get the list of tables in the database\n",
+        "cur.execute(f\"\"\"\n",
+        "    SELECT person_id, external_person_id\n",
+        "    FROM {DB_TABLE};\n",
+        "\"\"\")\n",
+        "\n",
+        "# Fetch the results\n",
+        "data = cur.fetchall()\n",
+        "data\n",
+        "\n",
+        "# Close the cursor and connection\n",
+        "cur.close()\n",
+        "conn.close()\n",
+        "\n",
+        "\n",
+        "# Prep the MPI data for merging with ECR data \n",
+        "columns=['person_id','external_person_id']\n",
+        "person = spark.createDataFrame(data = data, schema = columns)\n",
+        "\n",
+        "\n",
+        "# Load ecr Delta table\n",
+        "ecr = DeltaTable.forPath(spark,ECR_DELTA_TABLE_FILE_PATH)\n",
+        "\n",
+        "# Update ecr data with `external_person_id` from MPI by joining on `person_id`\n",
+        "ecr.alias(\"ecr\") \\\n",
+        "  .merge(\n",
+        "    person.alias(\"mpi_person\"),\n",
+        "    \"ecr.person_id = mpi_person.person_id\") \\\n",
+        "  .whenMatchedUpdate(set = { \"iris_id\": col(\"mpi_person.external_person_id\") }) \\\n",
+        "  .execute()\n",
+        "\n",
+        "ecr.toDF().show()\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "description": null,
+    "kernel_info": {
+      "name": "synapse_pyspark"
+    },
+    "kernelspec": {
+      "display_name": "Synapse PySpark",
+      "language": "Python",
+      "name": "synapse_pyspark"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "save_output": true,
+    "synapse_widget": {
+      "state": {},
+      "version": "0.1"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/scripts/Synapse/updateECRDataStorePersonID.ipynb
+++ b/scripts/Synapse/updateECRDataStorePersonID.ipynb
@@ -1,0 +1,157 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": true
+        }
+      },
+      "outputs": [],
+      "source": [
+        "pip install psycopg2-binary azure-keyvault"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false,
+          "source_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      },
+      "outputs": [],
+      "source": [
+        "from azure.identity import ManagedIdentityCredential\n",
+        "from azure.core.credentials import AccessToken\n",
+        "from azure.keyvault.secrets import SecretClient\n",
+        "import psycopg2\n",
+        "import time\n",
+        "\n",
+        "from delta.tables import *\n",
+        "from pyspark.sql.functions import *"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false,
+          "source_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      },
+      "outputs": [],
+      "source": [
+        "ECR_DELTA_TABLE_FILE_PATH = \"/delta/ecr\"\n",
+        "\n",
+        "# Set up authentication\n",
+        "class spoof_token:\n",
+        "    def get_token(*args, **kwargs):\n",
+        "        return AccessToken(\n",
+        "            token=mssparkutils.credentials.getToken(audience=\"vault\"),\n",
+        "            expires_on=int(time.time())+60*10 # some random time in future... synapse doesn't document how to get the actual time\n",
+        "        )\n",
+        "\n",
+        "credential = ManagedIdentityCredential()\n",
+        "credential._credential = spoof_token() # monkey-patch the contents of the private `_credential`\n",
+        "\n",
+        "# Set your Key Vault information\n",
+        "KEY_VAULT_URL = \"https://devvault9d194c64.vault.azure.net\"\n",
+        "DB_PASS_SECRET_NAME = \"mpi-password-test123\"\n",
+        "\n",
+        "# Create a SecretClient to interact with the Key Vault\n",
+        "secret_client = SecretClient(vault_url=KEY_VAULT_URL, credential=credential)\n",
+        "\n",
+        "# Retrieve the secret\n",
+        "db_pass_secret = secret_client.get_secret(DB_PASS_SECRET_NAME)\n",
+        "\n",
+        "# Database connection parameters\n",
+        "DB_NAME = \"DibbsMpiDB\"\n",
+        "DB_USER = \"postgres\"\n",
+        "DB_HOST = \"phdidevmpi9d194c64.postgres.database.azure.com\"\n",
+        "DB_PORT = \"5432\"\n",
+        "DB_TABLE = \"patient\"\n",
+        "\n",
+        "# Get the secret value (password) from the previous step\n",
+        "db_password = db_pass_secret.value\n",
+        "\n",
+        "# Connect to the database\n",
+        "conn = psycopg2.connect(\n",
+        "    dbname=DB_NAME,\n",
+        "    user=DB_USER,\n",
+        "    password=db_password,\n",
+        "    host=DB_HOST,\n",
+        "    port=DB_PORT\n",
+        ")\n",
+        "\n",
+        "# Create a cursor\n",
+        "cur = conn.cursor()\n",
+        "\n",
+        "# Execute the query to get the list of tables in the database\n",
+        "cur.execute(f\"\"\"\n",
+        "    SELECT patient_id,person_id\n",
+        "    FROM {DB_TABLE};\n",
+        "\"\"\")\n",
+        "\n",
+        "# Fetch the results\n",
+        "data = cur.fetchall()\n",
+        "\n",
+        "# Close the cursor and connection\n",
+        "cur.close()\n",
+        "conn.close()\n",
+        "\n",
+        "\n",
+        "# Prep the MPI data for merging with ECR data \n",
+        "columns=['patient_id','person_id']\n",
+        "patient = spark.createDataFrame(data = data, schema = columns)\n",
+        "\n",
+        "\n",
+        "# Load ecr Delta table\n",
+        "ecr = DeltaTable.forPath(spark,ECR_DELTA_TABLE_FILE_PATH)\n",
+        "\n",
+        "# Update ecr data with `person_id` from MPI by joining on `patient_id`\n",
+        "ecr.alias(\"ecr\") \\\n",
+        "  .merge(\n",
+        "    patient.alias(\"mpi\"),\n",
+        "    \"ecr.patient_id = mpi.patient_id\") \\\n",
+        "  .whenMatchedUpdate(set = { \"person_id\": col(\"mpi.person_id\") }) \\\n",
+        "  .execute()\n",
+        "\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "description": null,
+    "kernel_info": {
+      "name": "synapse_pyspark"
+    },
+    "kernelspec": {
+      "display_name": "Synapse PySpark",
+      "language": "Python",
+      "name": "synapse_pyspark"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "save_output": true,
+    "synapse_widget": {
+      "state": {},
+      "version": "0.1"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/scripts/Synapse/updateECRDataStorePersonID.ipynb
+++ b/scripts/Synapse/updateECRDataStorePersonID.ipynb
@@ -125,9 +125,9 @@
         "# Update ecr data with `person_id` from MPI by joining on `patient_id`\n",
         "ecr.alias(\"ecr\") \\\n",
         "  .merge(\n",
-        "    patient.alias(\"mpi\"),\n",
-        "    \"ecr.patient_id = mpi.patient_id\") \\\n",
-        "  .whenMatchedUpdate(set = { \"person_id\": col(\"mpi.person_id\") }) \\\n",
+        "    patient.alias(\"mpi_patient\"),\n",
+        "    \"ecr.patient_id = mpi_patient.patient_id\") \\\n",
+        "  .whenMatchedUpdate(set = { \"person_id\": col(\"mpi_patient.person_id\") }) \\\n",
         "  .execute()\n",
         "\n"
       ]


### PR DESCRIPTION
We need to ensure that iris_id can be refreshed/added to the eCR datastore. iris_id in the eCR dat store is equivalent to the external_person_id in the person table of the MPI. Therefore we need a job that can join the eCR datastore with the person table of the MPI on person_id in order to map external_person_id from the MPI in the iris_id column of the eCR data store.

Fixes #[503](https://app.zenhub.com/workspaces/dibbs-63f7aa3e1ecdbb0011edb299/issues/gh/cdcgov/phdi/503)