### PR TITLE
Target v1.0.2 images

### DIFF
--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -238,7 +238,7 @@ locals {
 
 data "docker_registry_image" "ghcr_data" {
   for_each = local.images
-  name     = "ghcr.io/cdcgov/phdi/${each.key}:v1.0.1"
+  name     = "ghcr.io/cdcgov/phdi/${each.key}:v1.0.2"
 }
 
 resource "docker_image" "ghcr_image" {

--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -238,7 +238,7 @@ locals {
 
 data "docker_registry_image" "ghcr_data" {
   for_each = local.images
-  name     = "ghcr.io/cdcgov/phdi/${each.key}:main"
+  name     = "ghcr.io/cdcgov/phdi/${each.key}:v1.0.1"
 }
 
 resource "docker_image" "ghcr_image" {


### PR DESCRIPTION
This will update our Terraform to pull down the the docker images tagged `v1.0.2` instead of `main`.