### PR TITLE
Add code to connect to record linkage container app from Synapse notebook

### DIFF
--- a/scripts/Synapse/convertParquetMPI.ipynb
+++ b/scripts/Synapse/convertParquetMPI.ipynb
@@ -94,15 +94,18 @@
         "access_token = response.json()['access_token']\n",
         "\n",
         "# Make request to record linkage container app\n",
-        "url = \"https://phdi-dev-record-linkage.victoriousocean-a1ab497b.centralus.azurecontainerapps.io\"\n",
+        "url = \"https://phdi-dev-record-linkage.victoriousocean-a1ab497b.centralus.azurecontainerapps.io/link-record\"\n",
         "\n",
         "headers = {\n",
         "    'Authorization': f'Bearer {access_token}'\n",
         "}\n",
         "\n",
-        "response = requests.get(url, headers=headers)\n",
-        "\n",
-        "print(response.json())"
+        "for iris_id, fhir_bundle in converted_data.items():\n",
+        "    data = {\n",
+        "        'bundle': fhir_bundle,\n",
+        "        'external_person_id': iris_id\n",
+        "    }\n",
+        "    requests.post(url, headers=headers, json=data)"
       ]
     }
   ],

--- a/scripts/Synapse/convertParquetMPI.ipynb
+++ b/scripts/Synapse/convertParquetMPI.ipynb
@@ -6,7 +6,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "pip install git+https://github.com/CDCgov/phdi"
+        "pip install git+https://github.com/CDCgov/phdi azure-keyvault-secrets"
       ]
     },
     {
@@ -45,6 +45,64 @@
         "    return converted_data\n",
         "\n",
         "converted_data = convert(mpi_incoming_file_path)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from azure.identity import ManagedIdentityCredential\n",
+        "from azure.core.credentials import AccessToken\n",
+        "\n",
+        "class spoof_token:\n",
+        "    def get_token(*args, **kwargs):\n",
+        "        return AccessToken(\n",
+        "            token=mssparkutils.credentials.getToken(audience=\"vault\"),\n",
+        "            expires_on=int(time.time())+60*10 # some random time in future... synapse doesn't document how to get the actual time\n",
+        "        )\n",
+        "\n",
+        "credential = ManagedIdentityCredential()\n",
+        "credential._credential = spoof_token() # monkey-patch the contents of the private `_credential`\n",
+        "\n",
+        "# Set up key vault client\n",
+        "from azure.keyvault.secrets import SecretClient\n",
+        "\n",
+        "vault_url = \"https://devvault9d194c64.vault.azure.net/\"\n",
+        "\n",
+        "client = SecretClient(vault_url=vault_url, credential=credential)\n",
+        "\n",
+        "# Get client ID and secret for GitHub app registration\n",
+        "client_id = client.get_secret(\"github-app-client-id\").value\n",
+        "client_secret = client.get_secret(\"github-app-client-secret\").value\n",
+        "\n",
+        "# Get access token for record linkage container app\n",
+        "import requests\n",
+        "\n",
+        "url = \"https://login.microsoftonline.com/28cf58df-efe8-4135-b2d1-f697ee74c00c/oauth2/v2.0/token\"\n",
+        "\n",
+        "data = {\n",
+        "    'grant_type': 'client_credentials',\n",
+        "    'client_id': client_id,\n",
+        "    'client_secret': client_secret,\n",
+        "    'scope': 'api://phdi-dev-record-linkage/.default'\n",
+        "}\n",
+        "\n",
+        "response = requests.post(url, data=data)\n",
+        "\n",
+        "access_token = response.json()['access_token']\n",
+        "\n",
+        "# Make request to record linkage container app\n",
+        "url = \"https://phdi-dev-record-linkage.victoriousocean-a1ab497b.centralus.azurecontainerapps.io\"\n",
+        "\n",
+        "headers = {\n",
+        "    'Authorization': f'Bearer {access_token}'\n",
+        "}\n",
+        "\n",
+        "response = requests.get(url, headers=headers)\n",
+        "\n",
+        "print(response.json())"
       ]
     }
   ],

--- a/terraform/modules/shared/data.tf
+++ b/terraform/modules/shared/data.tf
@@ -1,1 +1,5 @@
 data "azurerm_client_config" "current" {}
+
+data "azuread_application" "github_app" {
+  display_name = "github-${var.resource_group_name}"
+}

--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -174,6 +174,23 @@ resource "azurerm_key_vault_secret" "phi_storage_account_name" {
   key_vault_id = azurerm_key_vault.phdi_key_vault.id
 }
 
+resource "azuread_application_password" "github_app" {
+  application_object_id = data.azuread_application.github_app.object_id
+  display_name          = "github-app-client-secret"
+}
+
+resource "azurerm_key_vault_secret" "github_app_client_id" {
+  name         = "github-app-client-id"
+  value        = data.azuread_application.github_app.application_id
+  key_vault_id = azurerm_key_vault.phdi_key_vault.id
+}
+
+resource "azurerm_key_vault_secret" "github_app_client_secret" {
+  name         = "github-app-client-secret"
+  value        = azuread_application_password.github_app.value
+  key_vault_id = azurerm_key_vault.phdi_key_vault.id
+}
+
 ##### Container registry #####
 
 resource "azurerm_container_registry" "phdi_registry" {
@@ -520,12 +537,15 @@ resource "azurerm_synapse_firewall_rule" "allow_azure_services" {
 }
 
 resource "azurerm_synapse_spark_pool" "phdi" {
-  name                 = "sparkpool"
-  synapse_workspace_id = azurerm_synapse_workspace.phdi.id
-  node_size_family     = "MemoryOptimized"
-  node_size            = "Medium"
-  cache_size           = 100
-  spark_version        = 3.3
+  name                                = "sparkpool"
+  synapse_workspace_id                = azurerm_synapse_workspace.phdi.id
+  node_size_family                    = "MemoryOptimized"
+  node_size                           = "Small"
+  cache_size                          = 100
+  spark_version                       = 3.3
+  dynamic_executor_allocation_enabled = true
+  min_executors                       = 1
+  max_executors                       = 2
 
   auto_scale {
     max_node_count = 50


### PR DESCRIPTION
This adds a client secret to the app registration that GitHub uses for deployments (github-phdi in our env), adds it's client ID and secret to keyvault, and then Synapse uses it's managed identity credential to read those from the key vault, get an access token, and then makes a request to record linkage.