### PR TITLE
Validation if condition error improvements

### DIFF
--- a/terraform/modules/data_factory/ingestion-pipeline.json
+++ b/terraform/modules/data_factory/ingestion-pipeline.json
@@ -51,7 +51,7 @@
           },
           "ifFalseActivities": [
             {
-              "name": "Message validation failure",
+              "name": "message validation failure",
               "type": "Fail",
               "dependsOn": [],
               "userProperties": [],

--- a/terraform/modules/data_factory/ingestion-pipeline.json
+++ b/terraform/modules/data_factory/ingestion-pipeline.json
@@ -51,12 +51,12 @@
           },
           "ifFalseActivities": [
             {
-              "name": "Fail1",
+              "name": "Message validation failure",
               "type": "Fail",
               "dependsOn": [],
               "userProperties": [],
               "typeProperties": {
-                "message": "Validation failure, logging to validation failure storage.",
+                "message": "@{activity('validate_message').output}",
                 "errorCode": "422"
               }
             }


### PR DESCRIPTION
Improve error handling around validation failures and make it easier for users to find the error logs.

-Renamed the internal failure from the if statement from "Fail1" to "Message validation failure"
-Replaced the internal failure's unhelpful error message with the actual error output from the validation step of the pipeline.