### PR TITLE
Allow users to configure behavior of ReadSourceData when missing an RR

### DIFF
--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -107,10 +107,10 @@ def main(event: func.EventGridEvent) -> None:
                 missing_rr_message = (
                     "A reportability response could not be found for filename "
                     f"{container_name}/{filename} after searching for {wait_time} "  
-                    "seconds. The ingestion pipeline was not triggered. To search"
-                    "for a longer period of time, increase the value of the WAIT_TIME" 
+                    "seconds. The ingestion pipeline was not triggered. To search "
+                    "for a longer period of time, increase the value of the WAIT_TIME " 
                     "environment variable (default: 10 seconds). To allow processing of"
-                    "eICRs to continue without a reportability response, set the "
+                    " eICRs to continue without a reportability response, set the "
                     "REQUIRE_RR environment variable to 'false' (default: 'true')."
                 )
                 raise Exception(missing_rr_message)

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -130,9 +130,9 @@ def main(event: func.EventGridEvent) -> None:
                     "(default: 'true')."
                 )
                 logging.warning(missing_rr_message)
-
-        # Extract RR fields and put them in the ecr
-        ecr = rr_to_ecr(reportability_response, ecr)
+        else:
+            # Extract RR fields and put them in the ecr
+            ecr = rr_to_ecr(reportability_response, ecr)
 
         messages = [ecr]
 

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -130,7 +130,6 @@ def main(event: func.EventGridEvent) -> None:
                     "(default: 'true')."
                 )
                 logging.warning(missing_rr_message)
-            return
 
         # Extract RR fields and put them in the ecr
         ecr = rr_to_ecr(reportability_response, ecr)

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -98,10 +98,12 @@ def main(event: func.EventGridEvent) -> None:
             elif require_rr == "false":
                 require_rr = False
             else:
-                raise Exception(
+                error_message = (
                     "The environment variable REQUIRE_RR must be set to either 'true' "
                     "or 'false'."
                 )
+                logging.error(error_message)
+                raise Exception(error_message)
 
             if require_rr:
                 missing_rr_message = (

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -75,7 +75,7 @@ def main(event: func.EventGridEvent) -> None:
 
         wait_time = float(os.environ.get("WAIT_TIME", 10))
         sleep_time = float(os.environ.get("SLEEP_TIME", 1))
-
+            
         start_time = datetime.now()
         time_elapsed = 0
 
@@ -90,11 +90,42 @@ def main(event: func.EventGridEvent) -> None:
             )
 
         if reportability_response == "":
-            logging.warning(
-                "The ingestion pipeline was not triggered for this eCR, because a "
-                "reportability response was not found for filename "
-                f"{container_name}/{filename}."
-            )
+            # If no RR is found, check if we should continue processing the eICR and 
+            # trigger the pipeline.
+            require_rr = os.environ.get("REQUIRE_RR", "true").lower()
+            if require_rr == "true":
+                require_rr = True
+            elif require_rr == "false":
+                require_rr = False
+            else:
+                raise Exception(
+                    "The environment variable REQUIRE_RR must be set to either 'true' "
+                    "or 'false'."
+                )
+                
+            if require_rr:
+                missing_rr_message = (
+                    "A reportability response could not be found for filename "
+                    f"{container_name}/{filename} after searching for {wait_time} "  
+                    "seconds. The ingestion pipeline was not triggered. To search"
+                    "for a longer period of time, increase the value of the WAIT_TIME" 
+                    "environment variable (default: 10 seconds). To allow processing of"
+                    "eICRs to continue without a reportability response, set the "
+                    "REQUIRE_RR environment variable to 'false'."
+                )
+                raise Exception(missing_rr_message)
+            else:
+                missing_rr_message = (
+                    "A reportability response could not be found for filename "
+                    f"{container_name}/{filename} after searching for {wait_time} "  
+                    "seconds. The ingestion pipeline was triggered for this eICR "
+                    "without inclusion of the reportability response. To search for a "
+                    "longer period of time, increase the value of the WAIT_TIME "
+                    "environment variable (default: 10 seconds). To prevent further "
+                    "processing of eICRs to continue without a reportability response, "
+                    "set the REQUIRE_RR environment variable to 'false'."
+                )
+                logging.warning(missing_rr_message)
             return
 
         # Extract RR fields and put them in the ecr

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -75,7 +75,7 @@ def main(event: func.EventGridEvent) -> None:
 
         wait_time = float(os.environ.get("WAIT_TIME", 10))
         sleep_time = float(os.environ.get("SLEEP_TIME", 1))
-            
+
         start_time = datetime.now()
         time_elapsed = 0
 
@@ -90,7 +90,7 @@ def main(event: func.EventGridEvent) -> None:
             )
 
         if reportability_response == "":
-            # If no RR is found, check if we should continue processing the eICR and 
+            # If no RR is found, check if we should continue processing the eICR and
             # trigger the pipeline.
             require_rr = os.environ.get("REQUIRE_RR", "true").lower()
             if require_rr == "true":
@@ -102,13 +102,13 @@ def main(event: func.EventGridEvent) -> None:
                     "The environment variable REQUIRE_RR must be set to either 'true' "
                     "or 'false'."
                 )
-                
+
             if require_rr:
                 missing_rr_message = (
                     "A reportability response could not be found for filename "
-                    f"{container_name}/{filename} after searching for {wait_time} "  
+                    f"{container_name}/{filename} after searching for {wait_time} "
                     "seconds. The ingestion pipeline was not triggered. To search "
-                    "for a longer period of time, increase the value of the WAIT_TIME " 
+                    "for a longer period of time, increase the value of the WAIT_TIME "
                     "environment variable (default: 10 seconds). To allow processing of"
                     " eICRs to continue without a reportability response, set the "
                     "REQUIRE_RR environment variable to 'false' (default: 'true')."
@@ -118,13 +118,13 @@ def main(event: func.EventGridEvent) -> None:
             else:
                 missing_rr_message = (
                     "A reportability response could not be found for filename "
-                    f"{container_name}/{filename} after searching for {wait_time} "  
+                    f"{container_name}/{filename} after searching for {wait_time} "
                     "seconds. The ingestion pipeline was triggered for this eICR "
                     "without inclusion of the reportability response. To search for a "
                     "longer period of time, increase the value of the WAIT_TIME "
                     "environment variable (default: 10 seconds). To prevent further "
                     "processing of eICRs to continue without a reportability response, "
-                    "set the REQUIRE_RR environment variable to 'true' " 
+                    "set the REQUIRE_RR environment variable to 'true' "
                     "(default: 'true')."
                 )
                 logging.warning(missing_rr_message)

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -111,7 +111,7 @@ def main(event: func.EventGridEvent) -> None:
                     "for a longer period of time, increase the value of the WAIT_TIME" 
                     "environment variable (default: 10 seconds). To allow processing of"
                     "eICRs to continue without a reportability response, set the "
-                    "REQUIRE_RR environment variable to 'false'."
+                    "REQUIRE_RR environment variable to 'false' (default: 'true')."
                 )
                 raise Exception(missing_rr_message)
             else:
@@ -123,7 +123,8 @@ def main(event: func.EventGridEvent) -> None:
                     "longer period of time, increase the value of the WAIT_TIME "
                     "environment variable (default: 10 seconds). To prevent further "
                     "processing of eICRs to continue without a reportability response, "
-                    "set the REQUIRE_RR environment variable to 'false'."
+                    "set the REQUIRE_RR environment variable to 'true' " 
+                    "(default: 'true')."
                 )
                 logging.warning(missing_rr_message)
             return

--- a/serverless-functions/ReadSourceData/__init__.py
+++ b/serverless-functions/ReadSourceData/__init__.py
@@ -113,6 +113,7 @@ def main(event: func.EventGridEvent) -> None:
                     " eICRs to continue without a reportability response, set the "
                     "REQUIRE_RR environment variable to 'false' (default: 'true')."
                 )
+                logging.error(missing_rr_message)
                 raise Exception(missing_rr_message)
             else:
                 missing_rr_message = (

--- a/serverless-functions/tests/ReadSourceData/test_read_source_data.py
+++ b/serverless-functions/tests/ReadSourceData/test_read_source_data.py
@@ -229,19 +229,20 @@ def test_missing_rr_when_not_required(
     blob.read.return_value = b"some-blob-contents"
     wait_time = patched_os.environ["WAIT_TIME"]
     warning_message = (
-                    "A reportability response could not be found for filename "
-                    f"{blob.name} after searching for {wait_time} "  
-                    "seconds. The ingestion pipeline was triggered for this eICR "
-                    "without inclusion of the reportability response. To search for a "
-                    "longer period of time, increase the value of the WAIT_TIME "
-                    "environment variable (default: 10 seconds). To prevent further "
-                    "processing of eICRs to continue without a reportability response, "
-                    "set the REQUIRE_RR environment variable to 'true' " 
-                    "(default: 'true')."
-                )
+        "A reportability response could not be found for filename "
+        f"{blob.name} after searching for {wait_time} "
+        "seconds. The ingestion pipeline was triggered for this eICR "
+        "without inclusion of the reportability response. To search for a "
+        "longer period of time, increase the value of the WAIT_TIME "
+        "environment variable (default: 10 seconds). To prevent further "
+        "processing of eICRs to continue without a reportability response, "
+        "set the REQUIRE_RR environment variable to 'true' "
+        "(default: 'true')."
+    )
 
     read_source_data(event)
     patched_logging.warning.assert_called_with(warning_message)
+
 
 @mock.patch("ReadSourceData.os")
 @mock.patch("ReadSourceData.AzureCredentialManager")
@@ -279,20 +280,20 @@ def test_missing_rr_when_required(
     blob.read.return_value = b"some-blob-contents"
     wait_time = patched_os.environ["WAIT_TIME"]
     error_message = (
-                    "A reportability response could not be found for filename "
-                    f"{blob.name} after searching for {wait_time} "  
-                    "seconds. The ingestion pipeline was not triggered. To search "
-                    "for a longer period of time, increase the value of the WAIT_TIME " 
-                    "environment variable (default: 10 seconds). To allow processing of"
-                    " eICRs to continue without a reportability response, set the "
-                    "REQUIRE_RR environment variable to 'false' (default: 'true')."
-                )
+        "A reportability response could not be found for filename "
+        f"{blob.name} after searching for {wait_time} "
+        "seconds. The ingestion pipeline was not triggered. To search "
+        "for a longer period of time, increase the value of the WAIT_TIME "
+        "environment variable (default: 10 seconds). To allow processing of"
+        " eICRs to continue without a reportability response, set the "
+        "REQUIRE_RR environment variable to 'false' (default: 'true')."
+    )
     with pytest.raises(Exception) as error:
         read_source_data(event)
         patched_logging.error.assert_called_with(error_message)
         assert str(error) == (error_message)
 
-    
+
 def test_add_rr_to_ecr():
     with open("./tests/ReadSourceData/CDA_RR.xml", "r") as f:
         rr = f.read()

--- a/serverless-functions/tests/ReadSourceData/test_read_source_data.py
+++ b/serverless-functions/tests/ReadSourceData/test_read_source_data.py
@@ -193,6 +193,7 @@ def test_get_reportability_response_failure():
     )
 
 
+@mock.patch("ReadSourceData.DataFactoryManagementClient")
 @mock.patch("ReadSourceData.os")
 @mock.patch("ReadSourceData.AzureCredentialManager")
 @mock.patch("ReadSourceData.AzureCloudContainerConnection")
@@ -204,8 +205,17 @@ def test_missing_rr_when_not_required(
     patched_cloud_container_connection,
     patched_azure_cred_manager,
     patched_os,
+    patched_adf_management_client,
 ):
-    patched_os.environ = {"WAIT_TIME": 0.1, "SLEEP_TIME": 0.05, "REQUIRE_RR": "false"}
+    patched_os.environ = {
+        "AZURE_SUBSCRIPTION_ID": "some-subscription-id",
+        "RESOURCE_GROUP_NAME": "some-resource-group",
+        "FACTORY_NAME": "some-adf",
+        "PIPELINE_NAME": "some-pipeline",
+        "WAIT_TIME": 0.1,
+        "SLEEP_TIME": 0.05,
+        "REQUIRE_RR": "false",
+    }
     patched_azure_cred_manager.return_value.get_credentials.return_value = (
         "some-credentials"
     )
@@ -215,6 +225,12 @@ def test_missing_rr_when_not_required(
     )
 
     patched_get_reportability_response.return_value = ""
+
+    good_response = mock.Mock()
+    good_response.status_code = 200
+    adf_client = mock.MagicMock()
+    adf_client.pipelines.create_run.return_value = good_response
+    patched_adf_management_client.return_value = adf_client
 
     event = mock.MagicMock()
     event.get_json.return_value = {
@@ -242,6 +258,7 @@ def test_missing_rr_when_not_required(
 
     read_source_data(event)
     patched_logging.warning.assert_called_with(warning_message)
+    adf_client.pipelines.create_run.assert_called()
 
 
 @mock.patch("ReadSourceData.os")


### PR DESCRIPTION
This PR introduces a `REQUIRE_RR` environment variable to `ReadSourceData`. When `REQUIRE_RR` is `True`, the default value, and an RR cannot be found for an incoming eICR `ReadSourceData` will not trigger the ingestion pipeline, but instead log an error and raise an exception. When `REQUIRE_RR` is `False` and an RR cannot be found `ReadSourceData` will simply log a warning explaining that an RR wasn't found and then trigger the pipeline with only data from the eICR.