### PR TITLE
Add pipeline to update ecr datastore daily

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -237,6 +237,16 @@ jobs:
           az synapse pipeline create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Synapse Analytics Pipeline" --file @../../scripts/Synapse/config/SynapseAnalyticsPipelineConfig.json
           cat ../../scripts/Synapse/config/SynapseAnalyticsPipelineWeeklyTriggerConfig.json | envsubst > ../../scripts/Synapse/config/SynapseAnalyticsPipelineWeeklyTriggerConfigSubstituted.json
           az synapse trigger create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Synapse Analytics Pipeline Weekly Trigger" --file @../../scripts/Synapse/config/SynapseAnalyticsPipelineWeeklyTriggerConfigSubstituted.json
+      - name: Deploy Daily ECR Refresh Pipeline and Trigger
+        env:
+          TF_ENV: ${{ needs.terraform.outputs.tf_env }}
+          SHORT_CID: ${{ needs.terraform.outputs.short_cid }}
+          TENANT_ID: ${{ secrets.TENANT_ID }}
+        run: |
+          az synapse pipeline create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "ECR Datastore Refresh" --file @../../scripts/Synapse/config/ECRDatastoreRefreshConfig.json
+          cat ../../scripts/Synapse/config/ECRDatastoreRefreshDailyTriggerConfig.json | envsubst > ../../scripts/Synapse/config/ECRDatastoreRefreshDailyTriggerConfigSubstituted.json
+          az synapse trigger create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "ECR Datastore Refresh Daily Trigger" --file @../../scripts/Synapse/config/ECRDatastoreRefreshDailyTriggerConfigSubstituted.json
+
 
   end-to-end:
     name: End-to-end tests

--- a/scripts/Synapse/config/ECRDatastoreRefreshConfig.json
+++ b/scripts/Synapse/config/ECRDatastoreRefreshConfig.json
@@ -1,0 +1,33 @@
+{
+    "name": "ECR Datastore Refresh",
+    "properties": {
+        "description": "Updates the ECR Datastore daily with ECR data that has run through the DIBBs Pipeline",
+        "activities": [
+            {
+                "name": "UpdateECRDataStore",
+                "type": "SynapseNotebook",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "notebook": {
+                        "referenceName": "updateECRDataStore",
+                        "type": "NotebookReference"
+                    },
+                    "snapshot": true,
+                    "sparkPool": {
+                        "referenceName": "sparkpool",
+                        "type": "BigDataPoolReference"
+                    }
+                }
+            }
+        ],
+        "annotations": []
+    }
+}

--- a/scripts/Synapse/config/ECRDatastoreRefreshDailyTriggerConfig.json
+++ b/scripts/Synapse/config/ECRDatastoreRefreshDailyTriggerConfig.json
@@ -1,0 +1,32 @@
+{
+    "name": "ECR Datastore Refresh Daily Trigger",
+    "properties": {
+        "annotations": [],
+        "runtimeState": "Started",
+        "pipelines": [
+            {
+                "pipelineReference": {
+                    "referenceName": "ECR Datastore Refresh",
+                    "type": "PipelineReference"
+                }
+            }
+        ],
+        "type": "ScheduleTrigger",
+        "typeProperties": {
+            "recurrence": {
+                "frequency": "Day",
+                "interval": 1,
+                "startTime": "2023-07-20T17:30:00",
+                "timeZone": "Pacific Standard Time",
+                "schedule": {
+                    "minutes": [
+                        30
+                    ],
+                    "hours": [
+                        17
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Adds a new mini pipeline `ECR Datastore Refresh` to run the `updateECRDataStore` notebook
- Adds new trigger to execute the pipeline every day at 5:30pm PT

I tested deployment to `dev2` and successfully ran the pipeline with a manual trigger