### PR TITLE
Event-driven MII update

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -280,6 +280,23 @@ jobs:
           cat ../../scripts/Synapse/config/UpdateMPITriggerConfig.json | envsubst > ../../scripts/Synapse/config/UpdateMPITriggerConfigSubstituted.json
           az synapse trigger create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MPI Trigger" --file @../../scripts/Synapse/config/UpdateMPITriggerConfigSubstituted.json
           az synapse trigger start --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MPI Trigger"
+      - name: Deploy Update MII Pipeline and Trigger
+        env:
+          SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
+          RESOURCE_GROUP_NAME: ${{ secrets.RESOURCE_GROUP_NAME }}
+          TF_ENV: ${{ needs.terraform.outputs.tf_env }}
+          SHORT_CID: ${{ needs.terraform.outputs.short_cid }}
+        run: |
+          if az synapse trigger show --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MII Trigger"; then
+            az synapse trigger delete --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MII Trigger" --yes
+          fi
+          if az synapse pipeline show --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MII"; then
+            az synapse pipeline delete --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MII" --yes
+          fi
+          az synapse pipeline create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MII" --file @../../scripts/Synapse/config/UpdateMIIConfig.json
+          cat ../../scripts/Synapse/config/UpdateMIITriggerConfig.json | envsubst > ../../scripts/Synapse/config/UpdateMIITriggerConfigSubstituted.json
+          az synapse trigger create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MII Trigger" --file @../../scripts/Synapse/config/UpdateMIITriggerConfigSubstituted.json
+          az synapse trigger start --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MII Trigger"
   end-to-end:
     name: End-to-end tests
     needs: 

--- a/scripts/Synapse/config/UpdateMIIConfig.json
+++ b/scripts/Synapse/config/UpdateMIIConfig.json
@@ -1,0 +1,48 @@
+{
+    "name": "Update MII",
+    "properties": {
+        "activities": [
+            {
+                "name": "updateMII",
+                "type": "SynapseNotebook",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "notebook": {
+                        "referenceName": "updateMII",
+                        "type": "NotebookReference"
+                    },
+                    "parameters": {
+                        "filename": {
+                            "value": {
+                                "value": "@pipeline().parameters.triggeringFile",
+                                "type": "Expression"
+                            },
+                            "type": "string"
+                        }
+                    },
+                    "snapshot": true,
+                    "sparkPool": {
+                        "referenceName": "sparkpool",
+                        "type": "BigDataPoolReference"
+                    }
+                }
+            }
+        ],
+        "parameters": {
+            "triggeringFile": {
+                "type": "string"
+            }
+        },
+        "annotations": [],
+        "lastPublishTime": "2023-08-08T17:57:25Z"
+    },
+    "type": "Microsoft.Synapse/workspaces/pipelines"
+}

--- a/scripts/Synapse/config/UpdateMIITriggerConfig.json
+++ b/scripts/Synapse/config/UpdateMIITriggerConfig.json
@@ -1,0 +1,28 @@
+{
+    "name": "Update MII Trigger",
+    "properties": {
+        "annotations": [],
+        "runtimeState": "Started",
+        "pipelines": [
+            {
+                "pipelineReference": {
+                    "referenceName": "Update MII",
+                    "type": "PipelineReference"
+                },
+                "parameters": {
+                    "triggeringFile": "@trigger().outputs.body.fileName"
+                }
+            }
+        ],
+        "type": "BlobEventsTrigger",
+        "typeProperties": {
+            "blobPathBeginsWith": "/patient-data/blobs/MII",
+            "blobPathEndsWith": ".parquet",
+            "ignoreEmptyBlobs": true,
+            "scope": "/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP_NAME}/providers/Microsoft.Storage/storageAccounts/phdi${TF_ENV}phi${SHORT_CID}",
+            "events": [
+                "Microsoft.Storage.BlobCreated"
+            ]
+        }
+    }
+}

--- a/scripts/Synapse/updateECRDataStoreIncidentID.ipynb
+++ b/scripts/Synapse/updateECRDataStoreIncidentID.ipynb
@@ -106,7 +106,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Join the MII and ECR Datastore where the IDs match and the MII speciment collection date is within 90 days of the ECR `comparison_date` selected in the previous cell to assemble the updates for the ECR datastore."
+        "Join the MII and ECR Datastore where the IDs match and the MII specimen collection date is within 90 days of the ECR `comparison_date` selected in the previous cell to assemble the updates for the ECR datastore."
       ]
     },
     {

--- a/scripts/Synapse/updateECRDataStoreIncidentID.ipynb
+++ b/scripts/Synapse/updateECRDataStoreIncidentID.ipynb
@@ -8,7 +8,7 @@
         "### updateECRDatastoreIncidentID\n",
         "This is the 3rd and final step to update the ECR datastore after receiving new MPI data from LAC, after updating the `iris_id` in the `updateECRDatastoreIrisID` notebook.\n",
         "\n",
-        "This notebook syncs `incident_id`s between the Master Incident Index (MII) and the ECR datastore. As new MII data is made available through the `convertParquetMII` Synapse job, the ECR datastore needs to be updated as well. This notebook updates the `incident_id` column in the ECR datastore if there is an entry in the MII with a corresponding `person_id` and the entry has a positive COVID test within 90 days of the ECR datastore's COVID specimen collection date.\n"
+        "This notebook syncs `incident_id`s between the Master Incident Index (MII) and the ECR datastore. As new MII data is made available through the `updateMII` Synapse job, the ECR datastore needs to be updated as well. This notebook updates the `incident_id` column in the ECR datastore if there is an entry in the MII with a corresponding `person_id` and the entry has a positive COVID test within 90 days of the ECR datastore's COVID specimen collection date.\n"
       ]
     },
     {
@@ -36,7 +36,7 @@
         "\n",
         "account_name = \"$STORAGE_ACCOUNT\"\n",
         "ECR_DELTA_TABLE_FILE_PATH = f\"abfss://delta-tables@{account_name}.dfs.core.windows.net/ecr-datastore\"\n",
-        "MII_DELTA_TABLE_FILE_PATH = f\"abfss://delta-tables@{account_name}.dfs.core.windows.net/MII\"\n",
+        "MII_DELTA_TABLE_FILE_PATH = f\"abfss://patient_data@{account_name}.dfs.core.windows.net/MII.parquet\"\n",
         "COVID_IDENTIFICATION_CONFIG_FILE_PATH = f\"abfss://delta-tables@{account_name}.dfs.core.windows.net/covid_identification_config.json\"\n",
         "\n",
         "spark = SparkSession.builder.getOrCreate()\n",

--- a/scripts/Synapse/updateMII.ipynb
+++ b/scripts/Synapse/updateMII.ipynb
@@ -5,9 +5,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### convertParquetMII\n",
+        "### updateMII\n",
         "\n",
-        "This notebook inserts data from an uploaded parquet file (`mii_incoming_file_path`) into a Master Incident Index (MII) delta table (`mii_delta_table_path`). The parquet data are read into a spark dataframe and appended to the MII delta table."
+        "This notebook inserts data from an uploaded parquet file (`mii_incoming_file_path`) into a Master Incident Index (MII) delta table (`mii_delta_table_path`). "
       ]
     },
     {

--- a/scripts/Synapse/updateMII.ipynb
+++ b/scripts/Synapse/updateMII.ipynb
@@ -7,7 +7,7 @@
       "source": [
         "### updateMII\n",
         "\n",
-        "This notebook inserts data from an uploaded parquet file (`mii_incoming_file_path`) into a Master Incident Index (MII) delta table (`mii_delta_table_path`). "
+        "This notebook inserts and updates data from an uploaded parquet file (`mii_incoming_file_path`) into a Master Incident Index (MII) delta table (`mii_delta_table_path`). "
       ]
     },
     {
@@ -15,38 +15,99 @@
       "execution_count": null,
       "metadata": {
         "jupyter": {
-          "outputs_hidden": true
+          "outputs_hidden": false,
+          "source_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        },
+        "tags": [
+          "parameters"
+        ]
+      },
+      "outputs": [],
+      "source": [
+        "filename=\"\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false
         }
       },
       "outputs": [],
       "source": [
         "from pyspark.sql import SparkSession\n",
+        "from delta.tables import DeltaTable\n",
+        "from pyspark.sql.functions import col\n",
+        "from notebookutils import mssparkutils\n",
         "\n",
         "spark = SparkSession.builder.getOrCreate()\n",
         "\n",
         "# Set up file client\n",
-        "account_name = \"$STORAGE_ACCOUNT\"\n",
-        "mii_incoming_file_path = f\"abfss://patient-data@{account_name}.dfs.core.windows.net/MII.parquet\"\n",
-        "mii_delta_table_path = f\"abfss://delta-tables@{account_name}.dfs.core.windows.net/MII\"\n",
+        "storage_account = \"$STORAGE_ACCOUNT\"\n",
+        "mii_incoming_file_path = f\"abfss://patient-data@{storage_account}.dfs.core.windows.net/{filename}\"\n",
+        "mii_delta_table_path = f\"abfss://delta-tables@{storage_account}.dfs.core.windows.net/MII\"\n",
         "\n",
         "\n",
-        "def insert(mii_incoming_file_path,mii_delta_table_path):\n",
-        "    df = spark.read.parquet(mii_incoming_file_path)\n",
-        "    df.write.mode(\"append\").format(\"delta\").save(mii_delta_table_path)\n",
-        "    spark.read.parquet(mii_delta_table_path).show(5)\n",
+        "def update(mii_incoming_file_path,mii_delta_table_path):\n",
+        "    mii_updates = spark.read.parquet(mii_incoming_file_path)\n",
         "\n",
-        "insert(mii_incoming_file_path,mii_delta_table_path)"
+        "    # Check if MII Delta table exists\n",
+        "    if DeltaTable.isDeltaTable(spark, mii_delta_table_path):\n",
+        "        # If the table exists, update records\n",
+        "        mii_main = DeltaTable.forPath(spark, mii_delta_table_path)\n",
+        "\n",
+        "        mii_main.alias(\"mii_main\") \\\n",
+        "        .merge(\n",
+        "            mii_updates.alias(\"mii_updates\"),\n",
+        "            \"mii_updates.person_id = mii_main.person_id\") \\\n",
+        "        .whenMatchedUpdate(set ={\"incident_id\": \"mii_updates.incident_id\",\"specimen_collection_date\":\"mii_updates.specimen_collection_date\"}) \\\n",
+        "        .whenNotMatchedInsert(values = { \"person_id\": col(\"mii_updates.person_id\"),\n",
+        "        \"incident_id\": col(\"mii_updates.incident_id\"),\n",
+        "        \"specimen_collection_date\": col(\"mii_updates.specimen_collection_date\")}) \\\n",
+        "        .execute()\n",
+        "    else:\n",
+        "        # If Delta table doesn't exist, create it.\n",
+        "        mii_updates.write.format(\"delta\").mode(\"append\").save(mii_delta_table_path)\n",
+        "\n",
+        "    \n",
+        "\n",
+        "    \n",
+        "update(mii_incoming_file_path,mii_delta_table_path)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "outputs_hidden": false,
+          "source_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      },
+      "outputs": [],
+      "source": [
+        "# Move file that triggered the MII update event into the archive folder\n",
+        "destination = f\"abfss://patient-data@{storage_account}.dfs.core.windows.net/archive/{filename}\"\n",
+        "mssparkutils.fs.mv(src=mii_incoming_file_path,dest=destination,create_path=True)"
       ]
     }
   ],
   "metadata": {
     "description": null,
-    "kernel_info": {
-      "name": "synapse_pyspark"
-    },
     "kernelspec": {
       "display_name": "Synapse PySpark",
-      "language": "Python",
       "name": "synapse_pyspark"
     },
     "language_info": {


### PR DESCRIPTION
This PR ensures that the MII delta table is updated whenever a new file that starts with "MII" is added to the `patient-data` blob storage container.

-  `convertMII.ipynb` is renamed to `updateMII.ipynb`
-  `updateMII.ipynb` has an even-driven trigger for when a new file `MII*` is uploaded to `patient-data`
-  `updateMII.ipynb` upserts the updated data into the MII delta table
-  The file that triggered the notebook is moved into an `archive` folder within the `patient-data` container
-  `convertMII.ipynb` is removed from the Synapse Analytics Weekly pipeline

I tested the trigger creation and start from `dev2` and ensured that only new or updated incidents are added to the MII delta table from the uploaded file.