### PR TITLE
Add CSV export of `updated_ecr_datastore` file

### DIFF
--- a/scripts/Synapse/updateECRDataStore.ipynb
+++ b/scripts/Synapse/updateECRDataStore.ipynb
@@ -32,7 +32,7 @@
     "ECR_DATASTORE_PATH = DELTA_TABLES_FILESYSTEM + \"ecr-datastore\"\n",
     "ECR_DATASTORE_DAILY_EXTRACT_PATH = DELTA_TABLES_FILESYSTEM + \"ecr-datastore\"\n",
     "PARSED_ECR_PATH = DELTA_TABLES_FILESYSTEM + \"raw_data\"\n",
-    "DAILY_EXTRACT_FORMATS = [\"parquet\"]"
+    "DAILY_EXTRACT_FORMATS = [\"parquet\",\"csv\"]"
    ]
   },
   {
@@ -369,7 +369,7 @@
     "    # Force pyspark to coalesce the results into a single file\n",
     "    format_path = ECR_DATASTORE_DAILY_EXTRACT_PATH + \".\" + format\n",
     "    modified_datastore_directory = BASE_DATASTORE_DIRECTORY + \".\" + format + \"/\"\n",
-    "    ecr_datastore.coalesce(1).write.format(format).mode('overwrite').save(format_path)\n",
+    "    ecr_datastore.coalesce(1).write.format(format).option(\"header\",True).mode('overwrite').save(format_path)\n",
     "\n",
     "    # Locate the file which actually has the data amidst the pyspark kruft\n",
     "    partial_file = \"\"\n",


### PR DESCRIPTION
Adds CSV as an additional file format when the ecr datastore is updated.

I confirmed with PJ that the directly downloaded CSV (with synthetic data) null values look good to him.