### PR TITLE
Add KryoSerializer to spark_config

### DIFF
--- a/terraform/modules/shared/main.tf
+++ b/terraform/modules/shared/main.tf
@@ -563,9 +563,10 @@ resource "azurerm_synapse_spark_pool" "phdi" {
 
   spark_config {
     content  = <<EOF
-spark.shuffle.spill                true
+spark.kryoserializer.buffer.max 512
+spark.serializer org.apache.spark.serializer.KryoSerializer
 EOF
-    filename = "config.txt"
+    filename = "sparkpoolconfig.txt"
   }
 }
 


### PR DESCRIPTION
This PR adds terraform coverage to sparkpool config changes made in UAT environment to work with large dataset

