### PR TITLE
Add checkpointing for labeling and linkage

### DIFF
--- a/scripts/Synapse/analyzeLinkageAlgorithms.ipynb
+++ b/scripts/Synapse/analyzeLinkageAlgorithms.ipynb
@@ -120,6 +120,35 @@
         "\n",
         "from notebookutils import mssparkutils\n",
         "\n",
+        "# Functions for writing and reading results\n",
+        "\"\"\"\n",
+        "Function that writes the output of a linkage algorithm to a json file.\n",
+        "\"\"\"\n",
+        "def write_linkage_results(fname, results):\n",
+        "    # Results come in as a dict of ints to sets, so just json dumps it\n",
+        "    res_to_write = {str(k):[str(x) for x in list(v)] for (k,v) in results.items()}\n",
+        "    res_to_write = json.dumps(res_to_write)\n",
+        "    mssparkutils.fs.put(LINKAGE_OUTPUTS_FILESYSTEM + fname + \".json\", res_to_write, True)\n",
+        "\n",
+        "\n",
+        "\"\"\"\n",
+        "Function that loads the output of a linkage algorithm from a json file using spark.read\n",
+        "and converts it into the same format as the results dict (ints to sets).\n",
+        "\"\"\"\n",
+        "def load_linkage_results(fname):\n",
+        "    try:\n",
+        "        res = spark.read.json(LINKAGE_OUTPUTS_FILESYSTEM + fname + \".json\")\n",
+        "    except:\n",
+        "        print(\"Existing results not found.\")\n",
+        "        return None\n",
+        "    \n",
+        "    print(\"Existing results found!\")\n",
+        "    res = res.toPandas()\n",
+        "    res = res.to_dict()\n",
+        "    res = {int(k):set([int(x) for x in v[0]]) for (k,v) in res.items()}\n",
+        "    return res\n",
+        "    \n",
+        "\n",
         "# Set up for writing to blob storage\n",
         "linkage_bucket_name = \"linkage-notebook-outputs\"\n",
         "blob_sas_token = mssparkutils.credentials.getConnectionStringOrCreds(BLOB_STORAGE_LINKED_SERVICE)\n",
@@ -420,8 +449,10 @@
         "    matches = get_pred_match_dict_from_multi_idx(matches.index, len(data))\n",
         "    return matches\n",
         "\n",
-        "\n",
-        "va_labels = get_va_labels(labeling_set)"
+        "va_labels = load_linkage_results(\"va_labels\")\n",
+        "if va_labels is None:\n",
+        "    va_labels = get_va_labels(labeling_set)\n",
+        "    write_linkage_results(\"va_labels\", va_labels)"
       ]
     },
     {
@@ -503,7 +534,10 @@
         "    return matches\n",
         "\n",
         "\n",
-        "third_party_labels = predict_third_party_labels(labeling_set)"
+        "third_party_labels = load_linkage_results(\"third_party_labels\")\n",
+        "if third_party_labels is None:\n",
+        "    third_party_labels = predict_third_party_labels(labeling_set)\n",
+        "    write_linkage_results(\"third_party_labels\", third_party_labels)"
       ]
     },
     {
@@ -745,17 +779,7 @@
         "            match_dict[k] = match_dict[k].difference(lower_set)\n",
         "        if k in match_dict[k]:\n",
         "            match_dict[k].remove(k)\n",
-        "    return match_dict\n",
-        "\n",
-        "\n",
-        "\"\"\"\n",
-        "Function that writes the output of a linkage algorithm to a json file.\n",
-        "\"\"\"\n",
-        "def write_linkage_results(fname, results):\n",
-        "    # Results come in as a dict of ints to sets, so just json dumps it\n",
-        "    res_to_write = {str(k):[str(x) for x in list(v)] for (k,v) in results.items()}\n",
-        "    res_to_write = json.dumps(res_to_write)\n",
-        "    mssparkutils.fs.put(LINKAGE_OUTPUTS_FILESYSTEM + fname + \".json\", res_to_write, True)\n"
+        "    return match_dict\n"
       ]
     },
     {
@@ -812,9 +836,11 @@
         "    },\n",
         "]\n",
         "\n",
-        "found_matches_lac = link_all_fhir_records_block_dataset(evaluation_set, LAC_ALGO, labeling_set, formatted_cols)\n",
-        "found_matches_lac = dedupe_match_double_counts(found_matches_lac)\n",
-        "write_linkage_results(\"lac_algorithm_results\", found_matches_lac)"
+        "found_matches_lac = load_linkage_results(\"lac_algorithm_results\")\n",
+        "if found_matches_lac is None:\n",
+        "    found_matches_lac = link_all_fhir_records_block_dataset(evaluation_set, LAC_ALGO, labeling_set, formatted_cols)\n",
+        "    found_matches_lac = dedupe_match_double_counts(found_matches_lac)\n",
+        "    write_linkage_results(\"lac_algorithm_results\", found_matches_lac)"
       ]
     },
     {
@@ -825,9 +851,12 @@
       "source": [
         "# ALGORITHM EVALUATION: DIBBs BASIC\n",
         "from phdi.linkage import DIBBS_BASIC\n",
-        "found_matches_dibbs_basic = link_all_fhir_records_block_dataset(evaluation_set, DIBBS_BASIC, labeling_set, formatted_cols)\n",
-        "found_matches_dibbs_basic = dedupe_match_double_counts(found_matches_dibbs_basic)\n",
-        "write_linkage_results(\"dibbs_basic_algorithm_results\", found_matches_dibbs_basic)"
+        "\n",
+        "found_matches_dibbs_basic = load_linkage_results(\"dibbs_basic_algorithm_results\")\n",
+        "if found_matches_dibbs_basic is None:\n",
+        "    found_matches_dibbs_basic = link_all_fhir_records_block_dataset(evaluation_set, DIBBS_BASIC, labeling_set, formatted_cols)\n",
+        "    found_matches_dibbs_basic = dedupe_match_double_counts(found_matches_dibbs_basic)\n",
+        "    write_linkage_results(\"dibbs_basic_algorithm_results\", found_matches_dibbs_basic)"
       ]
     },
     {
@@ -838,9 +867,12 @@
       "source": [
         "# ALGORITHM EVALUATION: DIBBs ENHANCED\n",
         "from phdi.linkage import DIBBS_ENHANCED\n",
-        "found_matches_dibbs_enhanced = link_all_fhir_records_block_dataset(evaluation_set, DIBBS_ENHANCED, labeling_set, formatted_cols)\n",
-        "found_matches_dibbs_enhanced = dedupe_match_double_counts(found_matches_dibbs_enhanced)\n",
-        "write_linkage_results(\"dibbs_enhanced_algorithm_results\", found_matches_dibbs_enhanced)"
+        "\n",
+        "found_matches_dibbs_enhanced = load_linkage_results(\"dibbs_enhanced_algorithm_results\")\n",
+        "if found_matches_dibbs_enhanced is None:\n",
+        "    found_matches_dibbs_enhanced = link_all_fhir_records_block_dataset(evaluation_set, DIBBS_ENHANCED, labeling_set, formatted_cols)\n",
+        "    found_matches_dibbs_enhanced = dedupe_match_double_counts(found_matches_dibbs_enhanced)\n",
+        "    write_linkage_results(\"dibbs_enhanced_algorithm_results\", found_matches_dibbs_enhanced)"
       ]
     },
     {


### PR DESCRIPTION
This adds a `load_linkage_results` function which reads JSON files written by `write_linkage_results`, and loads them into variables in the correct format (dict of int to set). It also adds checks to each labeling and linking attempt to make sure we don't already have results written, if we do it loads them instead of running the labeling/linking again.