### PR TITLE
Refresh deployment token and fix MESSAGE_PARSER_URL

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -330,10 +330,11 @@ jobs:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
           subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
-          
+
       - name: Add custom schema to message parser
         env:
           MESSAGE_PARSER_URL: ${{ needs.terraform.outputs.message_parser_url }}
+          TF_ENV: ${{ needs.terraform.outputs.tf_env }}
         run: |
           # Get token for message parser
           TOKEN=$(az account get-access-token --resource api://phdi-${TF_ENV}-message-parser --query accessToken -o tsv)

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -28,7 +28,6 @@ jobs:
       tf_env: ${{ steps.set-environment.outputs.tf_env }}
       short_cid: ${{ steps.set-environment.outputs.short_cid }}
       record_linkage_container_url: ${{ steps.terraform.outputs.record_linkage_container_url }}
-      message_parser_url: ${{ steps.terraform.outputs.message_parser_url }}
     steps:
       - name: Check Out Changes
         uses: actions/checkout@v3
@@ -333,13 +332,14 @@ jobs:
 
       - name: Add custom schema to message parser
         env:
-          MESSAGE_PARSER_URL: ${{ needs.terraform.outputs.message_parser_url }}
           TF_ENV: ${{ needs.terraform.outputs.tf_env }}
         run: |
           # Get token for message parser
           TOKEN=$(az account get-access-token --resource api://phdi-${TF_ENV}-message-parser --query accessToken -o tsv)
           # Wrap ecr_datastore_config.json into variable
           ECR_DATASTORE_CONFIG=$(jq -n --argjson value "$(cat ../../scripts/Synapse/config/ecr_datastore_config.json)" '{"parsing_schema": $value}')
+          # Get message parser container app URL
+          MESSAGE_PARSER_URL=$(az containerapp show -g phdi -n phdi-${TF_ENV}-message-parser --query properties.configuration.ingress.fqdn -o tsv)
           # PUT ecr_datastore_config.json to message parser
           curl -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d "$ECR_DATASTORE_CONFIG" $MESSAGE_PARSER_URL/schemas/ecr.json
   end-to-end:

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -158,6 +158,14 @@ jobs:
           app-name: "$TF_ENV-read-source-data-$SHORT_CID"
           package: serverless-functions
           publish-profile: ${{ env.PUBLISH_PROFILE }}
+
+      - name: "Azure login"
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
+
       - name: Add Event Grid subscription
         env:
           SUBSCRIPTION_ID: ${{ secrets.SUBSCRIPTION_ID }}
@@ -259,6 +267,14 @@ jobs:
           cat ../../scripts/Synapse/config/SynapseAnalyticsPipelineWeeklyTriggerConfig.json | envsubst > ../../scripts/Synapse/config/SynapseAnalyticsPipelineWeeklyTriggerConfigSubstituted.json
           az synapse trigger create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Synapse Analytics Pipeline Weekly Trigger" --file @../../scripts/Synapse/config/SynapseAnalyticsPipelineWeeklyTriggerConfigSubstituted.json
           az synapse trigger start --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Synapse Analytics Pipeline Weekly Trigger"
+
+      - name: "Azure login"
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
+
       - name: Deploy Daily ECR Refresh Pipeline and Trigger
         env:
           TF_ENV: ${{ needs.terraform.outputs.tf_env }}
@@ -307,6 +323,14 @@ jobs:
           cat ../../scripts/Synapse/config/UpdateMIITriggerConfig.json | envsubst > ../../scripts/Synapse/config/UpdateMIITriggerConfigSubstituted.json
           az synapse trigger create --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MII Trigger" --file @../../scripts/Synapse/config/UpdateMIITriggerConfigSubstituted.json
           az synapse trigger start --workspace-name phdi${TF_ENV}synapse${SHORT_CID} --name "Update MII Trigger"
+
+      - name: "Azure login"
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.CLIENT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          subscription-id: ${{ secrets.SUBSCRIPTION_ID }}
+          
       - name: Add custom schema to message parser
         env:
           MESSAGE_PARSER_URL: ${{ needs.terraform.outputs.message_parser_url }}


### PR DESCRIPTION
Our deployment workflow often fails because the auth token for the Azure CLI often times out when steps run for too long. This adds a few extra "Azure login" steps in between steps to refresh the token, avoiding this.

Also actually sets MESSAGE_PARSER_URL correctly so that we can actually post the updated schema to the message parser container app.