### PR TITLE
Test deployment to lac

### DIFF
--- a/scripts/Synapse/analyzeLinkageAlgorithms.ipynb
+++ b/scripts/Synapse/analyzeLinkageAlgorithms.ipynb
@@ -23,7 +23,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install --upgrade pip"
+        "pip install --upgrade pip"
       ]
     },
     {

--- a/scripts/Synapse/convertParquetMPI.ipynb
+++ b/scripts/Synapse/convertParquetMPI.ipynb
@@ -16,7 +16,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install --upgrade pip"
+        "pip install --upgrade pip"
       ]
     },
     {

--- a/scripts/Synapse/convertParquetMPI.ipynb
+++ b/scripts/Synapse/convertParquetMPI.ipynb
@@ -25,7 +25,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "pip install phdi"
+        "pip install git+https://github.com/CDCgov/phdi@main"
       ]
     },
     {

--- a/scripts/Synapse/generateIRISCaseFiles.ipynb
+++ b/scripts/Synapse/generateIRISCaseFiles.ipynb
@@ -23,7 +23,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install --upgrade pip"
+        "pip install --upgrade pip"
       ]
     },
     {

--- a/scripts/Synapse/updateECRDataStore.ipynb
+++ b/scripts/Synapse/updateECRDataStore.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade pip"
+    "pip install --upgrade pip"
    ]
   },
   {

--- a/scripts/Synapse/updateECRDataStoreIncidentID.ipynb
+++ b/scripts/Synapse/updateECRDataStoreIncidentID.ipynb
@@ -25,7 +25,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install --upgrade pip"
+        "pip install --upgrade pip"
       ]
     },
     {

--- a/scripts/Synapse/updateECRDataStoreIrisID.ipynb
+++ b/scripts/Synapse/updateECRDataStoreIrisID.ipynb
@@ -17,7 +17,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install --upgrade pip"
+        "pip install --upgrade pip"
       ]
     },
     {

--- a/scripts/Synapse/updateECRDataStorePersonID.ipynb
+++ b/scripts/Synapse/updateECRDataStorePersonID.ipynb
@@ -17,7 +17,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install --upgrade pip"
+        "pip install --upgrade pip"
       ]
     },
     {

--- a/scripts/Synapse/updateMII.ipynb
+++ b/scripts/Synapse/updateMII.ipynb
@@ -16,7 +16,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "%pip install --upgrade pip"
+        "pip install --upgrade pip"
       ]
     },
     {


### PR DESCRIPTION
Removes `%` from pip install, which fails in Synapse

Installs phdi from github to ensure latest version is used