### PR TITLE
decrease retry count to 2

### DIFF
--- a/serverless-functions/host.json
+++ b/serverless-functions/host.json
@@ -14,12 +14,12 @@
   },
   "extensions": {
     "queues": {
-        "maxPollingInterval": "00:00:02",
-        "visibilityTimeout" : "00:00:30",
-        "batchSize": 16,
-        "maxDequeueCount": 5,
-        "newBatchThreshold": 8,
-        "messageEncoding": "base64"
+      "maxPollingInterval": "00:00:02",
+      "visibilityTimeout": "00:00:30",
+      "batchSize": 16,
+      "maxDequeueCount": 2,
+      "newBatchThreshold": 8,
+      "messageEncoding": "base64"
     }
-}
+  }
 }


### PR DESCRIPTION
This PR decreases retry count from 5 to 2 for messages in the queue to be picked up by `ReadSourceData`. We think this is an appropriate change for seeding because the vast majority of errors (and thus retries) stem from `ReadSourceData` attempting to insert the same record twice (thus violating the primary key constraints in the MPI)